### PR TITLE
Show text source of the opened file

### DIFF
--- a/photometric_viewer/formats/ies.py
+++ b/photometric_viewer/formats/ies.py
@@ -98,6 +98,9 @@ def import_from_file(f: IO):
             candela_values[(h_angle, v_angle)] = value
             n += 1
 
+    f.seek(0)
+    source = f.read()
+
     return Photometry(
         lumens=attributes["lumens_per_lamp"] * attributes["numer_of_lamps"] if attributes["lumens_per_lamp"] >= 0 else None,
         v_angles=v_angles,
@@ -120,7 +123,8 @@ def import_from_file(f: IO):
         metadata=PhotometryMetadata(
             luminaire=metadata.pop("LUMINAIRE", None),
             manufacturer=metadata.pop("MANUFAC", None),
-            additional_properties=metadata
+            additional_properties=metadata,
+            file_source=source
         )
     )
 

--- a/photometric_viewer/gui/content.py
+++ b/photometric_viewer/gui/content.py
@@ -1,5 +1,5 @@
-from gi.repository import Gtk
-from gi.repository.Gtk import Orientation
+from gi.repository import Gtk, Adw
+from gi.repository.Gtk import Orientation, PolicyType, ScrolledWindow
 
 from photometric_viewer.gui.geometry import LuminaireGeometry
 from photometric_viewer.gui.lamps import LampAndBallast
@@ -9,7 +9,7 @@ from photometric_viewer.gui.header import Header
 from photometric_viewer.gui.properties import LuminaireProperties
 
 
-class PhotometryContent(Gtk.Box):
+class PhotometryContent(Adw.Bin):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.diagram = PhotometricDiagram()
@@ -17,24 +17,35 @@ class PhotometryContent(Gtk.Box):
         self.geometry = LuminaireGeometry()
         self.lamps_and_ballast = LampAndBallast()
 
-        self.set_orientation(Orientation.VERTICAL)
-        self.set_spacing(16)
-        self.set_margin_top(32)
-        self.set_margin_bottom(32)
-        self.set_margin_start(16)
-        self.set_margin_end(16)
+        box = Gtk.Box(
+            orientation=Orientation.VERTICAL,
+            spacing=16,
+            margin_top=32,
+            margin_bottom=32,
+            margin_start=32,
+            margin_end=32
+        )
 
-        self.append(Header(label="Photometric diagram", xalign=0))
-        self.append(self.diagram)
+        box.append(Header(label="Photometric diagram", xalign=0))
+        box.append(self.diagram)
 
-        self.append(Header(label="Geometry", xalign=0))
-        self.append(self.geometry)
+        box.append(Header(label="Geometry", xalign=0))
+        box.append(self.geometry)
 
-        self.append(Header(label="Lamps and ballast", xalign=0))
-        self.append(self.lamps_and_ballast)
+        box.append(Header(label="Lamps and ballast", xalign=0))
+        box.append(self.lamps_and_ballast)
 
-        self.append(Header(label="Properties", xalign=0))
-        self.append(self.properties)
+        box.append(Header(label="Properties", xalign=0))
+        box.append(self.properties)
+
+        clamp = Adw.Clamp()
+        clamp.set_child(box)
+
+        scrolled_window = ScrolledWindow()
+        scrolled_window.set_child(clamp)
+        scrolled_window.set_vexpand(True)
+        scrolled_window.set_policy(PolicyType.NEVER, PolicyType.AUTOMATIC)
+        self.set_child(scrolled_window)
 
     def set_photometry(self, photometry: Photometry):
         self.diagram.set_photometry(photometry)

--- a/photometric_viewer/gui/empty.py
+++ b/photometric_viewer/gui/empty.py
@@ -1,0 +1,16 @@
+from gi.repository import Gtk, Adw
+from gi.repository.Gtk import Label, Orientation
+
+
+class EmptyPage(Adw.Bin):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        box = Gtk.Box(orientation=Orientation.VERTICAL, valign=Gtk.Align.CENTER, spacing=15)
+
+        box.append(Label(label="No content", name="no-content-header"))
+        box.append(Label(label="Open photometric file to display it here", name="no-content-subtitle"))
+
+        clamp = Adw.Clamp()
+        clamp.set_child(box)
+
+        self.set_child(clamp)

--- a/photometric_viewer/gui/source.py
+++ b/photometric_viewer/gui/source.py
@@ -1,0 +1,28 @@
+from gi.repository import Adw, Gtk
+from gi.repository.Gtk import ScrolledWindow, PolicyType
+
+from photometric_viewer.model.photometry import Photometry
+
+
+class SourceView(Adw.Bin):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.source_text_view = Gtk.TextView(
+            editable=False,
+            monospace=True,
+            wrap_mode=Gtk.WrapMode.WORD_CHAR,
+            left_margin=7,
+            right_margin=7,
+            top_margin=7,
+            bottom_margin=7
+        )
+
+        scrolled_window = ScrolledWindow()
+        scrolled_window.set_child(self.source_text_view)
+        scrolled_window.set_vexpand(True)
+        scrolled_window.set_policy(PolicyType.NEVER, PolicyType.AUTOMATIC)
+        self.set_child(scrolled_window)
+
+    def set_photometry(self, photometry: Photometry):
+        self.source_text_view.get_buffer().set_text(photometry.metadata.file_source)

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -1,9 +1,15 @@
+from typing import Optional
+
 from gi.repository import Adw, Gtk, Gio
+from gi.repository.Adw import ViewStackPage
 from gi.repository.Gtk import Label, Orientation, ScrolledWindow, PolicyType, Button, \
     FileChooserDialog, FileFilter, FileChooserNative
 
 from photometric_viewer.formats.ies import import_from_file
 from photometric_viewer.gui.content import PhotometryContent
+
+from photometric_viewer.gui.empty import EmptyPage
+from photometric_viewer.gui.source import SourceView
 from photometric_viewer.model.photometry import Photometry
 from photometric_viewer.utils.io import gio_file_stream
 
@@ -11,26 +17,28 @@ from photometric_viewer.utils.io import gio_file_stream
 class MainWindow(Adw.Window):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.opened_photometry = None
+        self.opened_photometry: Optional[Photometry] = None
 
-        self.set_default_size(600, 600)
+        self.set_default_size(550, 700)
         self.set_title(title='Photometric Viewer')
 
-        self.clamp = Adw.Clamp()
-
-        scrolled_window = ScrolledWindow()
-        scrolled_window.set_child(self.clamp)
-        scrolled_window.set_vexpand(True)
-        scrolled_window.set_policy(PolicyType.NEVER, PolicyType.AUTOMATIC)
+        self.content_bin = Adw.Bin()
+        self.content_bin.set_child(EmptyPage())
+        self.content_bin.set_vexpand(True)
 
         open_button = Button(label="Open")
         open_button.connect("clicked", self.on_open_clicked)
 
+        self.switcher_bar = Adw.ViewSwitcherTitle()
+        self.switcher_bar.set_title("Photometric Viewer")
+        self.switcher_bar.set_visible(True)
+
         box = Gtk.Box(orientation=Orientation.VERTICAL)
         header_bar = Adw.HeaderBar()
+        header_bar.set_title_widget(self.switcher_bar)
         header_bar.pack_start(open_button)
         box.append(header_bar)
-        box.append(scrolled_window)
+        box.append(self.content_bin)
 
         ies_filter = FileFilter(name="IESNA (*.ies)")
         ies_filter.add_pattern("*.ies")
@@ -49,20 +57,25 @@ class MainWindow(Adw.Window):
         self.file_chooser.add_filter(all_files_filter)
 
         self.set_content(box)
-        self.display_empty_content()
 
-    def display_photometry_content(self, photometry):
+    def display_photometry_content(self, photometry: Photometry):
         photometry_content = PhotometryContent()
         photometry_content.set_photometry(photometry)
-        self.clamp.set_child(photometry_content)
+
+        source_view = SourceView()
+        source_view.set_photometry(photometry)
+
+        view_stack = Adw.ViewStack()
+
+        properties_page: ViewStackPage = view_stack.add_titled(photometry_content, "properties", "Photometry")
+        properties_page.set_icon_name("view-reveal-symbolic")
+
+        source_page: ViewStackPage = view_stack.add_titled(source_view, "source", "Source")
+        source_page.set_icon_name("view-paged-symbolic")
+
+        self.content_bin.set_child(view_stack)
+        self.switcher_bar.set_stack(view_stack)
         self.opened_photometry = photometry
-
-    def display_empty_content(self):
-        box = Gtk.Box(orientation=Orientation.VERTICAL, valign=Gtk.Align.CENTER, spacing=16)
-
-        box.append(Label(label="No content", name="no-content-header"))
-        box.append(Label(label="Open photometric file to display it here", name="no-content-subtitle"))
-        self.clamp.set_child(box)
 
     def on_open_clicked(self, button):
         self.file_chooser.show()

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -67,7 +67,7 @@ class MainWindow(Adw.Window):
 
         view_stack = Adw.ViewStack()
 
-        properties_page: ViewStackPage = view_stack.add_titled(photometry_content, "properties", "Photometry")
+        properties_page: ViewStackPage = view_stack.add_titled(photometry_content, "photometry", "Photometry")
         properties_page.set_icon_name("view-reveal-symbolic")
 
         source_page: ViewStackPage = view_stack.add_titled(source_view, "source", "Source")

--- a/photometric_viewer/model/photometry.py
+++ b/photometric_viewer/model/photometry.py
@@ -8,6 +8,7 @@ class PhotometryMetadata:
     luminaire: str
     manufacturer: str
     additional_properties: Dict[str, str]
+    file_source: str
 
 
 class LuminousOpeningShape(Enum):


### PR DESCRIPTION
Allows the user to display the text content of the opened photometic file by switching to the "Source" tab.

Closes #5 