### PR TITLE
Display general information on top

### DIFF
--- a/photometric_viewer/gui/content.py
+++ b/photometric_viewer/gui/content.py
@@ -1,6 +1,7 @@
 from gi.repository import Gtk, Adw
 from gi.repository.Gtk import Orientation, PolicyType, ScrolledWindow
 
+from photometric_viewer.gui.general import GeneralLuminaireInformation
 from photometric_viewer.gui.geometry import LuminaireGeometry
 from photometric_viewer.gui.lamps import LampAndBallast
 from photometric_viewer.model.photometry import Photometry
@@ -13,9 +14,10 @@ class PhotometryContent(Adw.Bin):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.diagram = PhotometricDiagram()
-        self.properties = LuminaireProperties()
+        self.general_information = GeneralLuminaireInformation()
         self.geometry = LuminaireGeometry()
         self.lamps_and_ballast = LampAndBallast()
+        self.properties = LuminaireProperties()
 
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
@@ -29,13 +31,16 @@ class PhotometryContent(Adw.Bin):
         box.append(Header(label="Photometric diagram", xalign=0))
         box.append(self.diagram)
 
+        box.append(Header(label="General information", xalign=0))
+        box.append(self.general_information)
+
         box.append(Header(label="Geometry", xalign=0))
         box.append(self.geometry)
 
         box.append(Header(label="Lamps and ballast", xalign=0))
         box.append(self.lamps_and_ballast)
 
-        box.append(Header(label="Properties", xalign=0))
+        box.append(Header(label="Additional properties", xalign=0))
         box.append(self.properties)
 
         clamp = Adw.Clamp()
@@ -49,7 +54,8 @@ class PhotometryContent(Adw.Bin):
 
     def set_photometry(self, photometry: Photometry):
         self.diagram.set_photometry(photometry)
+        self.general_information.set_photometry(photometry)
         self.geometry.set_photometry(photometry)
-        self.properties.set_photometry(photometry)
         self.lamps_and_ballast.set_photometry(photometry)
+        self.properties.set_photometry(photometry)
 

--- a/photometric_viewer/gui/general.py
+++ b/photometric_viewer/gui/general.py
@@ -2,12 +2,13 @@ from photometric_viewer.gui.widgets.common import PropertyList
 from photometric_viewer.model.photometry import Photometry
 
 
-class LuminaireProperties(PropertyList):
+class GeneralLuminaireInformation(PropertyList):
     def set_photometry(self, photometry: Photometry):
         items = [i for i in self]
 
         for child in items:
             self.remove(child)
 
-        for key, value in photometry.metadata.additional_properties.items():
-            self.append(self._create_item(name=key, value=value))
+        self.append(self._create_item(name="Name", value=photometry.metadata.luminaire))
+        self.append(self._create_item(name="Manufacturer", value=photometry.metadata.manufacturer))
+


### PR DESCRIPTION
Name and manufacturer are now displayed on top of all properties, directly below the photometric curve. This allows the user to find this information easier among all the properties

Closes #11 