### PR TITLE
Display multi-line values

### DIFF
--- a/photometric_viewer/formats/ies.py
+++ b/photometric_viewer/formats/ies.py
@@ -59,11 +59,19 @@ def import_from_file(f: IO):
 
     metadata = {}
     next_line = _read_non_empty_line(f)
+    last_key = None
     while next_line.startswith("["):
         metadata_line = next_line.split("]")
         metadata_key = metadata_line[0].strip("[").strip()
         metadata_value = metadata_line[1].strip()
-        metadata[metadata_key] = metadata_value
+        if metadata_key == 'MORE' and last_key is not None:
+            metadata[last_key] = metadata[last_key] + "\n" + metadata_value
+        elif metadata_key in metadata.keys():
+            metadata[metadata_key] = metadata[metadata_key] + "\n" + metadata_value
+            last_key = metadata_key
+        else:
+            metadata[metadata_key] = metadata_value
+            last_key = metadata_key
         next_line = _read_non_empty_line(f)
 
     raw_attributes = _get_n_values(f, 10)
@@ -121,6 +129,7 @@ def import_from_file(f: IO):
             catalog_number=metadata.pop("BALLASTCAT", None),
         ),
         metadata=PhotometryMetadata(
+            catalog_number=metadata.pop("LUMCAT", None),
             luminaire=metadata.pop("LUMINAIRE", None),
             manufacturer=metadata.pop("MANUFAC", None),
             additional_properties=metadata,

--- a/photometric_viewer/gui/general.py
+++ b/photometric_viewer/gui/general.py
@@ -9,6 +9,7 @@ class GeneralLuminaireInformation(PropertyList):
         for child in items:
             self.remove(child)
 
-        self.append(self._create_item(name="Name", value=photometry.metadata.luminaire))
+        self.append(self._create_item(name="Catalog Number", value=photometry.metadata.catalog_number))
         self.append(self._create_item(name="Manufacturer", value=photometry.metadata.manufacturer))
+        self.append(self._create_item(name="Description", value=photometry.metadata.luminaire, wrap=True))
 

--- a/photometric_viewer/gui/properties.py
+++ b/photometric_viewer/gui/properties.py
@@ -10,4 +10,4 @@ class LuminaireProperties(PropertyList):
             self.remove(child)
 
         for key, value in photometry.metadata.additional_properties.items():
-            self.append(self._create_item(name=key, value=value))
+            self.append(self._create_item(name=key.title().replace("_", " ").strip(), value=value))

--- a/photometric_viewer/gui/widgets/common.py
+++ b/photometric_viewer/gui/widgets/common.py
@@ -2,7 +2,7 @@ from gi.repository import Gtk
 from gi.repository.GObject import Property
 from gi.repository.Gdk import Clipboard, ContentProvider
 from gi.repository.Gtk import Box, Orientation, Label, SelectionMode, Button
-from gi.repository.Pango import EllipsizeMode
+from gi.repository.Pango import EllipsizeMode, WrapMode
 
 
 class PropertyList(Gtk.ListBox):
@@ -11,32 +11,42 @@ class PropertyList(Gtk.ListBox):
         self.set_css_classes(["boxed-list"])
         self.set_selection_mode(SelectionMode.NONE)
 
-    def _create_item(self, name, value):
-        box = Box(orientation=Orientation.HORIZONTAL)
-        box.set_spacing(128)
+    def _create_item(self, name, value:str, wrap=False):
+        box = Box(orientation=Orientation.VERTICAL)
+        box.set_homogeneous(False)
+        box.set_spacing(4)
         box.set_margin_start(16)
         box.set_margin_end(16)
         box.set_margin_top(16)
         box.set_margin_bottom(16)
 
         name_label = Label(label=name, hexpand=True, xalign=0)
+        name_label.set_css_classes(["h1"])
+
+        displayed_value = value.replace("\n", " ") if wrap else value
 
         value_label = Label(
-            label=value or "Unknown",
-            hexpand=True,
-            xalign=1,
+            label=displayed_value or "Unknown",
             css_classes=[] if value else ["warning"]
         )
-        value_label.set_ellipsize(EllipsizeMode.END)
         value_label.set_tooltip_text(value)
-        value_label.set_width_chars(8)
+        value_label.set_hexpand(True)
+        value_label.set_xalign(0)
 
-        copy_button: Button = Button.new_from_icon_name("edit-copy")
-        copy_button.connect("clicked", self.on_copy_clicked, value)
+        if wrap:
+            value_label.set_wrap(True)
+            value_label.set_wrap_mode(WrapMode.WORD_CHAR)
+        else:
+            value_label.set_ellipsize(EllipsizeMode.END)
+            value_label.set_width_chars(16)
 
         value_box = Box(orientation=Orientation.HORIZONTAL, spacing=16)
         value_box.append(value_label)
-        value_box.append(copy_button)
+
+        if value:
+            copy_button: Button = Button.new_from_icon_name("edit-copy")
+            copy_button.connect("clicked", self.on_copy_clicked, value)
+            value_box.append(copy_button)
 
         box.append(name_label)
         box.append(value_box)

--- a/photometric_viewer/model/photometry.py
+++ b/photometric_viewer/model/photometry.py
@@ -6,6 +6,7 @@ from typing import Dict, Tuple, List
 @dataclass
 class PhotometryMetadata:
     luminaire: str
+    catalog_number: str
     manufacturer: str
     additional_properties: Dict[str, str]
     file_source: str


### PR DESCRIPTION
It is now possible to read multiple lines of the luminaire properties file marked with `[MORE]` or specified by reusing the same tag multiple times in the IES .

For better display, properties are displayed in two rows instead of two columns now: the value is displayed below the key instead of next to it.

Additional fixes to the UI:

  - "Copy to clipboard" button is not visible if there is no value to be copied in the first place