### PR TITLE
Make value labels selectable with mouse

### DIFF
--- a/photometric_viewer/gui/general.py
+++ b/photometric_viewer/gui/general.py
@@ -11,5 +11,5 @@ class GeneralLuminaireInformation(PropertyList):
 
         self.append(self._create_item(name="Catalog Number", value=photometry.metadata.catalog_number))
         self.append(self._create_item(name="Manufacturer", value=photometry.metadata.manufacturer))
-        self.append(self._create_item(name="Description", value=photometry.metadata.luminaire, wrap=True))
+        self.append(self._create_item(name="Description", value=photometry.metadata.luminaire))
 

--- a/photometric_viewer/gui/widgets/common.py
+++ b/photometric_viewer/gui/widgets/common.py
@@ -1,7 +1,6 @@
 from gi.repository import Gtk
-from gi.repository.GObject import Property
 from gi.repository.Gdk import Clipboard, ContentProvider
-from gi.repository.Gtk import Box, Orientation, Label, SelectionMode, Button
+from gi.repository.Gtk import Box, Orientation, Label, SelectionMode
 from gi.repository.Pango import EllipsizeMode, WrapMode
 
 
@@ -27,11 +26,12 @@ class PropertyList(Gtk.ListBox):
 
         value_label = Label(
             label=displayed_value or "Unknown",
+            tooltip_text=value,
+            hexpand=True,
+            xalign=0,
+            selectable=True,
             css_classes=[] if value else ["warning"]
         )
-        value_label.set_tooltip_text(value)
-        value_label.set_hexpand(True)
-        value_label.set_xalign(0)
 
         if wrap:
             value_label.set_wrap(True)
@@ -40,16 +40,8 @@ class PropertyList(Gtk.ListBox):
             value_label.set_ellipsize(EllipsizeMode.END)
             value_label.set_width_chars(16)
 
-        value_box = Box(orientation=Orientation.HORIZONTAL, spacing=16)
-        value_box.append(value_label)
-
-        if value:
-            copy_button: Button = Button.new_from_icon_name("edit-copy")
-            copy_button.connect("clicked", self.on_copy_clicked, value)
-            value_box.append(copy_button)
-
         box.append(name_label)
-        box.append(value_box)
+        box.append(value_label)
 
         return box
 

--- a/photometric_viewer/gui/widgets/common.py
+++ b/photometric_viewer/gui/widgets/common.py
@@ -10,7 +10,7 @@ class PropertyList(Gtk.ListBox):
         self.set_css_classes(["boxed-list"])
         self.set_selection_mode(SelectionMode.NONE)
 
-    def _create_item(self, name, value:str, wrap=False):
+    def _create_item(self, name, value: str):
         box = Box(orientation=Orientation.VERTICAL)
         box.set_homogeneous(False)
         box.set_spacing(4)
@@ -22,23 +22,16 @@ class PropertyList(Gtk.ListBox):
         name_label = Label(label=name, hexpand=True, xalign=0)
         name_label.set_css_classes(["h1"])
 
-        displayed_value = value.replace("\n", " ") if wrap else value
-
         value_label = Label(
-            label=displayed_value or "Unknown",
+            label=value or "Unknown",
             tooltip_text=value,
             hexpand=True,
             xalign=0,
             selectable=True,
-            css_classes=[] if value else ["warning"]
+            wrap=True,
+            wrap_mode=WrapMode.WORD_CHAR,
+            css_classes=[] if value else ["warning"],
         )
-
-        if wrap:
-            value_label.set_wrap(True)
-            value_label.set_wrap_mode(WrapMode.WORD_CHAR)
-        else:
-            value_label.set_ellipsize(EllipsizeMode.END)
-            value_label.set_width_chars(16)
 
         box.append(name_label)
         box.append(value_label)


### PR DESCRIPTION
Instead of providing copy button, let the user select the text with mouse cursor. This makes the usage more intuitive and let's the user to copy only parts of the value if needed.