### PR TITLE
Add "About" dialog

### DIFF
--- a/photometric_viewer/gui/about.py
+++ b/photometric_viewer/gui/about.py
@@ -1,0 +1,19 @@
+from gi.repository import Adw, Gtk
+
+
+class AboutWindow():
+    def __init__(self):
+        self._about_window = Adw.AboutWindow(
+            application_name="Photomertic Viewer",
+            application_icon="io.github.dlippok.photometric-viewer",
+            developer_name="Damian Lippok",
+            version="0.2",
+            website="https://github.com/dlippok/photometric-viewer",
+            issue_url="https://github.com/dlippok/photometric-viewer/issues",
+            copyright="© 2023 Damian Lippok",
+            license_type=Gtk.License.MIT_X11
+        )
+
+
+    def show(self):
+        self._about_window.show()

--- a/photometric_viewer/gui/menu.py
+++ b/photometric_viewer/gui/menu.py
@@ -1,0 +1,25 @@
+from gi.repository import Gtk
+
+
+class ApplicationMenuButton(Gtk.MenuButton):
+    MENU_MODEL = """
+    <?xml version="1.0"?>
+        <interface>
+        <menu id='app-menu'>
+            <section>
+                <item>
+                    <attribute name='label' translatable='yes'>About Photometric Viewer</attribute>
+                    <attribute name='action'>app.show_about_window</attribute>
+                </item>
+            </section>
+        </menu>
+        </interface>
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        builder = Gtk.Builder.new_from_string(self.MENU_MODEL, -1)
+        menu_model = builder.get_object("app-menu")
+        self.set_menu_model(menu_model)
+        self.set_icon_name("open-menu-symbolic")

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -6,9 +6,11 @@ from gi.repository.Gtk import Label, Orientation, ScrolledWindow, PolicyType, Bu
     FileChooserDialog, FileFilter, FileChooserNative
 
 from photometric_viewer.formats.ies import import_from_file
+from photometric_viewer.gui.about import AboutWindow
 from photometric_viewer.gui.content import PhotometryContent
 
 from photometric_viewer.gui.empty import EmptyPage
+from photometric_viewer.gui.menu import ApplicationMenuButton
 from photometric_viewer.gui.source import SourceView
 from photometric_viewer.model.photometry import Photometry
 from photometric_viewer.utils.io import gio_file_stream
@@ -21,6 +23,8 @@ class MainWindow(Adw.Window):
 
         self.set_default_size(550, 700)
         self.set_title(title='Photometric Viewer')
+
+        self.install_action("app.show_about_window", None, self.show_about_dialog)
 
         self.content_bin = Adw.Bin()
         self.content_bin.set_child(EmptyPage())
@@ -37,6 +41,7 @@ class MainWindow(Adw.Window):
         header_bar = Adw.HeaderBar()
         header_bar.set_title_widget(self.switcher_bar)
         header_bar.pack_start(open_button)
+        header_bar.pack_end(ApplicationMenuButton())
         box.append(header_bar)
         box.append(self.content_bin)
 
@@ -90,3 +95,7 @@ class MainWindow(Adw.Window):
         if photometry.metadata.luminaire:
             self.set_title(title=photometry.metadata.luminaire)
         self.display_photometry_content(photometry)
+
+    def show_about_dialog(self, *args):
+        window = AboutWindow()
+        window.show()


### PR DESCRIPTION
Allows users to open a "About" dialog window containing author information and legal information and links to the project page and issue tracker.