### PR TITLE
Switch between displayed lamp sets

### DIFF
--- a/photometric_viewer/gui/lamps.py
+++ b/photometric_viewer/gui/lamps.py
@@ -1,30 +1,52 @@
+from gi.repository import Adw
+from gi.repository.Gtk import Box, Orientation
+
 from photometric_viewer.gui.widgets.common import PropertyList
 from photometric_viewer.model.photometry import Photometry
 
 
-class LampAndBallast(PropertyList):
-    def _create_if_exists(self, key, value):
-        if value:
-            self.append(self._create_item(name=key, value=value))
+class LampAndBallast(Adw.Bin):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.view_stack = Adw.ViewStack()
+
+        switcher_bar = Adw.ViewSwitcherBar(
+            stack=self.view_stack,
+            reveal=True,
+            name="lamp-switcher-bar"
+        )
+
+        box = Box(
+            orientation=Orientation.VERTICAL,
+            spacing=8
+        )
+        box.append(self.view_stack)
+        box.append(switcher_bar)
+        self.set_child(box)
 
     def set_photometry(self, photometry: Photometry):
-        items = [i for i in self]
+        items = [i for i in self.view_stack]
 
         for child in items:
-            self.remove(child)
+            self.view_stack.remove(child)
 
-        for lamp in photometry.lamps:
-            self.append(self._create_item(name="Number of lamps", value=str(lamp.number_of_lamps)))
-            self._create_if_exists("Lamp", lamp.description)
-            self._create_if_exists("Lamp catalog no.", lamp.catalog_number)
-            self._create_if_exists("Color", lamp.color)
-            self._create_if_exists("Color Rendering Index (CRI)", lamp.cri)
-            self._create_if_exists("Wattage", lamp.wattage)
+        for n, lamp in enumerate(photometry.lamps):
+            property_list = PropertyList()
+            property_list.add("Number of lamps", str(lamp.number_of_lamps))
+            property_list.add_if_non_empty("Lamp", lamp.description)
+            property_list.add_if_non_empty("Lamp catalog no.", lamp.catalog_number)
+            property_list.add_if_non_empty("Color", lamp.color)
+            property_list.add_if_non_empty("Color Rendering Index (CRI)", lamp.cri)
+            property_list.add_if_non_empty("Wattage", lamp.wattage)
 
             if not photometry.is_absolute:
-                self.append(self._create_item(name="Initial rating per lamp", value=f'{lamp.lumens_per_lamp:.0f}lm'))
+                property_list.add("Initial rating per lamp", f'{lamp.lumens_per_lamp:.0f}lm')
 
-            self._create_if_exists("Lamp position", lamp.position)
-            self._create_if_exists("Ballast", lamp.ballast_description)
-            self._create_if_exists("Ballast catalog no.", lamp.ballast_catalog_number)
+            property_list.add_if_non_empty("Lamp position", lamp.position)
+            property_list.add_if_non_empty("Ballast", lamp.ballast_description)
+            property_list.add_if_non_empty("Ballast catalog no.", lamp.ballast_catalog_number)
+
+            page_name = lamp.description or f"Lamp {n}"
+            page = self.view_stack.add_titled(property_list, f"lamp_{n}", page_name)
+            page.set_icon_name("io.github.dlippok.photometric-viewer-symbolic")
 

--- a/photometric_viewer/gui/widgets/common.py
+++ b/photometric_viewer/gui/widgets/common.py
@@ -38,6 +38,13 @@ class PropertyList(Gtk.ListBox):
 
         return box
 
+    def add(self, name: str, value: str):
+        self.append(self._create_item(name=name, value=value))
+
+    def add_if_non_empty(self, name: str, value: str):
+        if value:
+            self.append(self._create_item(name=name, value=value))
+
     def on_copy_clicked(self, a, value):
         clipboard: Clipboard = self.get_clipboard()
         provider = ContentProvider.new_for_value(value)

--- a/photometric_viewer/styles/style.css
+++ b/photometric_viewer/styles/style.css
@@ -17,6 +17,10 @@
     color: alpha(@window_fg_color, 0.5);
 }
 
+#lamp-switcher-bar>actionbar>revealer>box {
+   background-color: @window_bg_color;
+}
+
 .unknown_value {
     color: @shade_color;
 }


### PR DESCRIPTION
Eulumdat files can contain more than one lamp set per luminaire. Instead of displaying all lamp sets one below the other, the application now displays only one of them at a time and lets the user to switch between them via a switcher bar.