### PR TITLE
Allow user to select preferred units

### DIFF
--- a/data/io.github.dlippok.photometric-viewer.gschema.xml
+++ b/data/io.github.dlippok.photometric-viewer.gschema.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <enum id="io.github.dlippok.photometric-viewer.length-units-enum">
+      <value nick="meters" value="1"/>
+      <value nick="centimeters" value="2"/>
+      <value nick="millimeters" value="3"/>
+      <value nick="feet" value="4"/>
+      <value nick="inches" value="5"/>
+  </enum>
+  <schema id="io.github.dlippok.photometric-viewer" path="/apps/io/github/dlippok/photometric-viewer/">
+      <key type="b" name="length-units-from-file">
+          <default>false</default>
+          <summary>Use length unit from photometric file</summary>
+          <description>Whenever applicable, display length the same units as used in the photometric file instead of the selected ones.</description>
+      </key>
+      <key enum="io.github.dlippok.photometric-viewer.length-units-enum" name="preferred-length-units">
+          <default>'meters'</default>
+          <summary>Preferred units to be used when displaying length values</summary>
+          <description>All length values from the photometric file will be converted to the selected unit when displaying in the UI.</description>
+      </key>
+  </schema>
+</schemalist>

--- a/photometric_viewer/formats/ies.py
+++ b/photometric_viewer/formats/ies.py
@@ -3,6 +3,7 @@ from typing import IO
 from photometric_viewer.formats.exceptions import InvalidLuminousOpeningException
 from photometric_viewer.model.photometry import Photometry, PhotometryMetadata, LuminousOpeningGeometry, Shape, \
     Lamps
+from photometric_viewer.model.units import LengthUnits
 from photometric_viewer.utils.io import read_non_empty_line
 
 
@@ -131,6 +132,7 @@ def import_from_file(f: IO):
             luminaire=metadata.pop("LUMINAIRE", None),
             manufacturer=metadata.pop("MANUFAC", None),
             additional_properties=metadata,
-            file_source=source
+            file_source=source,
+            file_units=LengthUnits.FEET if attributes["luminous_opening_units"] == 1 else LengthUnits.METERS
         )
     )

--- a/photometric_viewer/formats/ldt.py
+++ b/photometric_viewer/formats/ldt.py
@@ -2,6 +2,7 @@ from typing import IO
 
 from photometric_viewer.model.photometry import Photometry, LuminousOpeningGeometry, Shape, Lamps, \
     PhotometryMetadata, LuminaireGeometry
+from photometric_viewer.model.units import LengthUnits
 
 
 def _create_luminous_opening(length, width) -> LuminousOpeningGeometry:
@@ -157,6 +158,7 @@ def import_from_file(f: IO):
             luminaire=luminaire_name,
             manufacturer=manufacturer,
             file_source=source,
+            file_units=LengthUnits.METERS,
             additional_properties={
                 "Luminaire type": _get_source_type(light_source_type),
                 "Measurement": measurement,

--- a/photometric_viewer/gui/content.py
+++ b/photometric_viewer/gui/content.py
@@ -9,6 +9,7 @@ from photometric_viewer.model.photometry import Photometry
 from photometric_viewer.gui.diagram import PhotometricDiagram
 from photometric_viewer.gui.header import Header
 from photometric_viewer.gui.properties import LuminaireProperties
+from photometric_viewer.model.settings import Settings
 
 
 class PhotometryContent(Adw.Bin):
@@ -64,3 +65,6 @@ class PhotometryContent(Adw.Bin):
         self.geometry.set_photometry(photometry)
         self.lamps_and_ballast.set_photometry(photometry)
         self.properties.set_photometry(photometry)
+
+    def update_settings(self, settings: Settings):
+        self.geometry.update_settings(settings)

--- a/photometric_viewer/gui/geometry.py
+++ b/photometric_viewer/gui/geometry.py
@@ -1,26 +1,69 @@
 from photometric_viewer.gui.widgets.common import PropertyList
 from photometric_viewer.model.photometry import Photometry, Shape, LuminousOpeningGeometry, LuminaireGeometry
+from photometric_viewer.model.settings import Settings
+from photometric_viewer.model.units import LengthUnits, length_factor
 
 
 class LuminaireGeometryProperties(PropertyList):
+    def __init__(self):
+        super().__init__()
+        self.photometry: Photometry | None = None
+        self.settings: Settings | None = None
+
     def set_photometry(self, photometry: Photometry):
+        self.photometry = photometry
+        self._refresh_widgets()
+
+    def update_settings(self, settings: Settings):
+        self.settings = settings
+        self._refresh_widgets()
+
+    def _convert(self, value):
+        if not self.settings:
+            return f"{value}m"
+
+        if self.settings.length_units_from_file:
+            converted_value = value * length_factor(self.photometry.metadata.file_units)
+            match self.photometry.metadata.file_units:
+                case LengthUnits.METERS:
+                    return f"{converted_value:.2f}m"
+                case LengthUnits.FEET:
+                    return f"{converted_value:.2f}ft"
+        else:
+            converted_value = value * length_factor(self.settings.length_units)
+            match self.settings.length_units:
+                case LengthUnits.METERS:
+                    return f"{converted_value:.2f}m"
+                case LengthUnits.CENTIMETERS:
+                    return f"{converted_value:.2f}cm"
+                case LengthUnits.MILLIMETERS:
+                    return f"{converted_value:.2f}mm"
+                case LengthUnits.FEET:
+                    return f"{converted_value:.2f}ft"
+                case LengthUnits.INCHES:
+                    return f"{converted_value:.2f}in"
+
+    def _refresh_widgets(self):
+        if not self.photometry:
+            return
+
         items = [i for i in self]
 
         for child in items:
             self.remove(child)
 
-        match photometry.luminaire_geometry:
+        match self.photometry.luminaire_geometry:
             case LuminaireGeometry(w, l, h, Shape.RECTANGULAR):
                 self.add("Luminaire shape", "Rectangular")
-                self.add("Luminaire dimensions", f"{w:.2f}m x {l:.2f}m x {h:.2f}m")
+                self.add("Luminaire dimensions", f"{self._convert(w)} x {self._convert(l)} x {self._convert(h)}")
             case LuminaireGeometry(w, l, h, Shape.ROUND):
                 self.add("Luminaire shape", "Round")
-                self.add("Luminaire dimensions", f"{w:.2f}m x {l:.2f}m x {h:.2f}m")
+                self.add("Luminaire dimensions", f"{self._convert(w)} x {self._convert(l)} x {self._convert(h)}")
 
-        match photometry.luminous_opening_geometry:
+        match self.photometry.luminous_opening_geometry:
             case LuminousOpeningGeometry(w, l, Shape.RECTANGULAR):
                 self.add("Luminous opening shape", "Rectangular")
-                self.add("Luminous opening dimensions", f"{w:.2f}m x {l:.2f}m")
+                self.add("Luminous opening dimensions", f"{self._convert(w)} x {self._convert(l)}")
             case LuminousOpeningGeometry(w, l, Shape.ROUND):
                 self.add("Luminous opening shape", "Round")
-                self.add("Luminous opening dimensions", f"{w:.2f}m x {l:.2f}m")
+                self.add("Luminous opening dimensions", f"{self._convert(w)} x {self._convert(l)}")

--- a/photometric_viewer/gui/menu.py
+++ b/photometric_viewer/gui/menu.py
@@ -8,6 +8,10 @@ class ApplicationMenuButton(Gtk.MenuButton):
         <menu id='app-menu'>
             <section>
                 <item>
+                    <attribute name='label' translatable='yes'>Preferences</attribute>
+                    <attribute name='action'>app.show_preferences</attribute>
+                </item>
+                <item>
                     <attribute name='label' translatable='yes'>About Photometric Viewer</attribute>
                     <attribute name='action'>app.show_about_window</attribute>
                 </item>

--- a/photometric_viewer/gui/settings/settings.py
+++ b/photometric_viewer/gui/settings/settings.py
@@ -1,0 +1,121 @@
+from gi.repository import Adw, Gtk
+from gi.repository.Gtk import ListBox, Box, Orientation, Label, SelectionMode
+
+from photometric_viewer.model.settings import Settings
+from photometric_viewer.model.units import LengthUnits
+
+
+class PreferencesWindow(Adw.PreferencesWindow):
+    """
+    <?xml version="1.0"?>
+        <interface>
+        <menu id='app-menu'>
+            <section>
+                <item>
+                    <attribute name='label' translatable='yes'>Preferences</attribute>
+                    <attribute name='action'>app.show_preferences</attribute>
+                </item>
+                <item>
+                    <attribute name='label' translatable='yes'>About Photometric Viewer</attribute>
+                    <attribute name='action'>app.show_about_window</attribute>
+                </item>
+            </section>
+        </menu>
+        </interface>
+    """
+
+    def __init__(self, settings: Settings, on_update_settings, **kwargs):
+        super().__init__(**kwargs)
+        self.set_search_enabled(False)
+        self.settings = settings
+        self.on_update_settings = on_update_settings
+        self._add_units_page()
+
+    def _add_units_page(self):
+        page = Adw.PreferencesPage(
+            title="Application Settings",
+        )
+
+        units_group = Adw.PreferencesGroup(
+            title="Units",
+            description="Measurement units displayed in the application"
+        )
+
+        units_group_list = ListBox(
+            css_classes=["boxed-list"],
+            selection_mode=SelectionMode.NONE
+        )
+        use_units_from_file_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            spacing=4,
+            margin_start=16,
+            margin_end=16,
+            margin_top=16,
+            margin_bottom=16
+        )
+        use_units_from_file_box.append(Label(label="Use units from photometric file", hexpand=True, xalign=0))
+        switch = Gtk.Switch(active=self.settings.length_units_from_file)
+        switch.connect("state-set", self.length_units_from_file_state_set)
+        use_units_from_file_box.append(switch)
+
+        self.preferred_units_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            spacing=4,
+            margin_start=16,
+            margin_end=16,
+            margin_top=16,
+            margin_bottom=16
+        )
+        self.preferred_units_box.append(Label(label="Preferred length units", hexpand=True, xalign=0))
+        self.preferred_units_dropdown: Gtk.DropDown = Gtk.DropDown.new_from_strings([
+            "Meters",
+            "Centimeters",
+            "Millimeters",
+            "Feet",
+            "Inches"
+        ])
+
+        match self.settings.length_units:
+            case LengthUnits.METERS:
+                self.preferred_units_dropdown.set_selected(0)
+            case LengthUnits.CENTIMETERS:
+                self.preferred_units_dropdown.set_selected(1)
+            case LengthUnits.MILLIMETERS:
+                self.preferred_units_dropdown.set_selected(2)
+            case LengthUnits.FEET:
+                self.preferred_units_dropdown.set_selected(3)
+            case LengthUnits.INCHES:
+                self.preferred_units_dropdown.set_selected(4)
+
+        self.preferred_units_dropdown.connect("notify::selected", self.preferred_unit_changed)
+
+        self.preferred_units_box.append(self.preferred_units_dropdown)
+
+        units_group_list.append(use_units_from_file_box)
+        units_group_list.append(self.preferred_units_box)
+        units_group.add(units_group_list)
+
+        page.add(units_group)
+        self.add(page)
+
+    def preferred_unit_changed(self, *args):
+        match self.preferred_units_dropdown.get_selected():
+            case 0:
+                self.settings.length_units = LengthUnits.METERS
+            case 1:
+                self.settings.length_units = LengthUnits.CENTIMETERS
+            case 2:
+                self.settings.length_units = LengthUnits.MILLIMETERS
+            case 3:
+                self.settings.length_units = LengthUnits.FEET
+            case 4:
+                self.settings.length_units = LengthUnits.INCHES
+        self.update()
+
+    def length_units_from_file_state_set(self, widget, state, *args):
+        self.settings.length_units_from_file = state
+        self.preferred_units_box.set_sensitive(not state)
+        self.update()
+
+    def update(self):
+        self.on_update_settings()

--- a/photometric_viewer/gui/settings/settings.py
+++ b/photometric_viewer/gui/settings/settings.py
@@ -64,7 +64,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
             margin_start=16,
             margin_end=16,
             margin_top=16,
-            margin_bottom=16
+            margin_bottom=16,
+            sensitive=not self.settings.length_units_from_file
         )
         self.preferred_units_box.append(Label(label="Preferred length units", hexpand=True, xalign=0))
         self.preferred_units_dropdown: Gtk.DropDown = Gtk.DropDown.new_from_strings([

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -9,20 +9,26 @@ from photometric_viewer.gui.about import AboutWindow
 from photometric_viewer.gui.content import PhotometryContent
 from photometric_viewer.gui.empty import EmptyPage
 from photometric_viewer.gui.menu import ApplicationMenuButton
+from photometric_viewer.gui.settings.settings import PreferencesWindow
 from photometric_viewer.gui.source import SourceView
 from photometric_viewer.model.photometry import Photometry
+from photometric_viewer.model.settings import Settings
+from photometric_viewer.model.units import LengthUnits
 from photometric_viewer.utils.io import gio_file_stream
 
 
 class MainWindow(Adw.Window):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.settings = Settings(length_units_from_file=False, length_units=LengthUnits.METERS)
         self.opened_photometry: Optional[Photometry] = None
+        self.photometry_content = PhotometryContent()
 
         self.set_default_size(550, 700)
         self.set_title(title='Photometric Viewer')
 
         self.install_action("app.show_about_window", None, self.show_about_dialog)
+        self.install_action("app.show_preferences", None, self.show_preferences)
 
         self.content_bin = Adw.Bin()
         self.content_bin.set_child(EmptyPage())
@@ -71,15 +77,15 @@ class MainWindow(Adw.Window):
         self.set_content(box)
 
     def display_photometry_content(self, photometry: Photometry):
-        photometry_content = PhotometryContent()
-        photometry_content.set_photometry(photometry)
+        self.photometry_content = PhotometryContent()
+        self.photometry_content.set_photometry(photometry)
 
         source_view = SourceView()
         source_view.set_photometry(photometry)
 
         view_stack = Adw.ViewStack()
 
-        properties_page: ViewStackPage = view_stack.add_titled(photometry_content, "photometry", "Photometry")
+        properties_page: ViewStackPage = view_stack.add_titled(self.photometry_content, "photometry", "Photometry")
         properties_page.set_icon_name("view-reveal-symbolic")
 
         source_page: ViewStackPage = view_stack.add_titled(source_view, "source", "Source")
@@ -88,6 +94,9 @@ class MainWindow(Adw.Window):
         self.content_bin.set_child(view_stack)
         self.switcher_bar.set_stack(view_stack)
         self.opened_photometry = photometry
+
+    def update_settings(self):
+        self.photometry_content.update_settings(self.settings)
 
     def on_open_clicked(self, _):
         self.file_chooser.show()
@@ -102,6 +111,12 @@ class MainWindow(Adw.Window):
         if photometry.metadata.luminaire:
             self.set_title(title=photometry.metadata.luminaire)
         self.display_photometry_content(photometry)
+        self.photometry_content.update_settings(self.settings)
+
+
+    def show_preferences(self, *args):
+        window = PreferencesWindow(self.settings, self.update_settings)
+        window.show()
 
     @staticmethod
     def show_about_dialog(*args):

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -14,13 +14,15 @@ from photometric_viewer.gui.source import SourceView
 from photometric_viewer.model.photometry import Photometry
 from photometric_viewer.model.settings import Settings
 from photometric_viewer.model.units import LengthUnits
+from photometric_viewer.utils.GSettings import GSettings
 from photometric_viewer.utils.io import gio_file_stream
 
 
 class MainWindow(Adw.Window):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.settings = Settings(length_units_from_file=False, length_units=LengthUnits.METERS)
+        self.gsettings = GSettings()
+        self.settings = self.gsettings.load()
         self.opened_photometry: Optional[Photometry] = None
         self.photometry_content = PhotometryContent()
 
@@ -97,6 +99,7 @@ class MainWindow(Adw.Window):
 
     def update_settings(self):
         self.photometry_content.update_settings(self.settings)
+        self.gsettings.save(self.settings)
 
     def on_open_clicked(self, _):
         self.file_chooser.show()

--- a/photometric_viewer/main.py
+++ b/photometric_viewer/main.py
@@ -39,13 +39,13 @@ class Application(Adw.Application):
     def do_shutdown(self):
         Adw.Application.do_shutdown(self)
 
+
     def do_open(self, *args, **kwargs):
         file: Gio.File = args[0][0]
         with gio_file_stream(file) as f:
             photometry = import_from_file(f)
             self.win.open_photometry(photometry)
         self.props.active_window.present()
-
 
 def run():
     app = Application()

--- a/photometric_viewer/model/photometry.py
+++ b/photometric_viewer/model/photometry.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Tuple, List
 
+from photometric_viewer.model.units import LengthUnits
+
 
 @dataclass
 class PhotometryMetadata:
@@ -10,6 +12,7 @@ class PhotometryMetadata:
     manufacturer: str
     additional_properties: Dict[str, str]
     file_source: str
+    file_units: LengthUnits
 
 
 class Shape(Enum):

--- a/photometric_viewer/model/settings.py
+++ b/photometric_viewer/model/settings.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from photometric_viewer.model.units import LengthUnits
+
+
+@dataclass
+class Settings:
+    length_units_from_file: bool
+    length_units: LengthUnits | None

--- a/photometric_viewer/model/units.py
+++ b/photometric_viewer/model/units.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+M_IN_FEET = 0.3048
+
+
+class LengthUnits(Enum):
+    METERS = 1
+    CENTIMETERS = 2
+    MILLIMETERS = 3
+    FEET = 4
+    INCHES = 5
+
+
+def length_factor(units: LengthUnits):
+    match units:
+        case LengthUnits.METERS:
+            return 1
+        case LengthUnits.CENTIMETERS:
+            return 100
+        case LengthUnits.MILLIMETERS:
+            return 1000
+        case LengthUnits.FEET:
+            return 3.2808
+        case LengthUnits.INCHES:
+            return 39.3701

--- a/photometric_viewer/utils/GSettings.py
+++ b/photometric_viewer/utils/GSettings.py
@@ -1,0 +1,32 @@
+from gi.repository import Gio
+
+from photometric_viewer.model.settings import Settings
+from photometric_viewer.model.units import LengthUnits
+
+
+class GSettings:
+    SCHEMA_ID = "io.github.dlippok.photometric-viewer"
+    settings: Gio.Settings | None = None
+
+    def __init__(self):
+        if self.SCHEMA_ID in Gio.Settings.list_schemas():
+            self.settings: Gio.Settings | None = Gio.Settings.new(self.SCHEMA_ID)
+        else:
+            print("Could not load GSettings. Using default value")
+            self.settings = None
+
+    def save(self, settings: Settings):
+        if not self.settings:
+            return
+
+        self.settings.set_boolean("length-units-from-file", settings.length_units_from_file)
+        self.settings.set_enum("preferred-length-units", settings.length_units.value)
+
+    def load(self):
+        if not self.settings:
+            return Settings(length_units_from_file=False, length_units=LengthUnits.METERS)
+
+        return Settings(
+            length_units_from_file=self.settings.get_boolean("length-units-from-file"),
+            length_units=LengthUnits(self.settings.get_enum("preferred-length-units"))
+        )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
+import os
+
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+from subprocess import check_call
+
+
+class InstallCommand(install):
+    def run(self):
+        install.run(self)
+        check_call(["glib-compile-schemas", os.path.join(self.install_data, "share/glib-2.0/schemas/")])
+
 
 setup(name='photometric-viewer',
       version='0.2',
@@ -8,17 +19,21 @@ setup(name='photometric-viewer',
       author_email='mail.dalee@gmail.com',
       license='MIT',
       packages=find_packages(),
+      cmdclass={
+          'install': InstallCommand,
+      },
       entry_points={
-        'console_scripts': ['photometric-viewer=photometric_viewer.main:run'],
+          'console_scripts': ['photometric-viewer=photometric_viewer.main:run'],
       },
       package_data={
-            'photometric_viewer': ['styles/style.css'],
+          'photometric_viewer': ['styles/style.css'],
       },
       data_files=[
-            ('share/icons/hicolor/scalable/apps', ['data/icons/io.github.dlippok.photometric-viewer.svg']),
-            ('share/icons/hicolor/symbolic/apps', ['data/icons/io.github.dlippok.photometric-viewer-symbolic.svg']),
-            ('share/applications', ['data/desktop/io.github.dlippok.photometric-viewer.desktop']),
-            ('share/mime/packages', ['data/desktop/io.github.dlippok.photometric-viewer.mime.xml']),
-            ('share/metainfo', ['data/io.github.dlippok.photometric-viewer.metainfo.xml'])
+          ('share/icons/hicolor/scalable/apps', ['data/icons/io.github.dlippok.photometric-viewer.svg']),
+          ('share/icons/hicolor/symbolic/apps', ['data/icons/io.github.dlippok.photometric-viewer-symbolic.svg']),
+          ('share/applications', ['data/desktop/io.github.dlippok.photometric-viewer.desktop']),
+          ('share/mime/packages', ['data/desktop/io.github.dlippok.photometric-viewer.mime.xml']),
+          ('share/metainfo', ['data/io.github.dlippok.photometric-viewer.metainfo.xml']),
+          ('share/glib-2.0/schemas/', ['data/io.github.dlippok.photometric-viewer.gschema.xml'])
       ],
       zip_safe=False)


### PR DESCRIPTION
Allow user to select preferred length units or use units from the photometric file Instead of forcing display in meters.

**WIP**:
- [x] Persist selected settings in the gsetting store
- [x] Code cleanups

Closes #8 