### PR TITLE
Display length units correctly

### DIFF
--- a/photometric_viewer/gui/geometry.py
+++ b/photometric_viewer/gui/geometry.py
@@ -27,6 +27,8 @@ class LuminaireGeometryProperties(PropertyList):
             match self.photometry.metadata.file_units:
                 case LengthUnits.METERS:
                     return f"{converted_value:.2f}m"
+                case LengthUnits.MILLIMETERS:
+                    return f"{converted_value:.0f}mm"
                 case LengthUnits.FEET:
                     return f"{converted_value:.2f}ft"
         else:
@@ -35,9 +37,9 @@ class LuminaireGeometryProperties(PropertyList):
                 case LengthUnits.METERS:
                     return f"{converted_value:.2f}m"
                 case LengthUnits.CENTIMETERS:
-                    return f"{converted_value:.2f}cm"
+                    return f"{converted_value:.1f}cm"
                 case LengthUnits.MILLIMETERS:
-                    return f"{converted_value:.2f}mm"
+                    return f"{converted_value:.0f}mm"
                 case LengthUnits.FEET:
                     return f"{converted_value:.2f}ft"
                 case LengthUnits.INCHES:


### PR DESCRIPTION
Fixes bug which makes the software display None lengths when using length units form the EULUMDAT file and shows more convenient number of significant digits when using metric system.