### PR TITLE
Limit build to supported architectures

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,7 +5,12 @@ confinement: strict
 
 environment:
   PYTHONPATH: ${SNAP}/lib/python3.10/site-packages:${SNAP}/usr/lib/python3/dist-packages
-
+  
+architectures:
+  - build-on: arm64
+  - build-on: armhf
+  - build-on: amd64
+  
 apps:
   photometric-viewer:
     extensions:


### PR DESCRIPTION
See https://github.com/dlippok/photometric-viewer/issues/22