### PR TITLE
Display error message instead of crashing while opening invalid file

### DIFF
--- a/photometric_viewer/formats/exceptions.py
+++ b/photometric_viewer/formats/exceptions.py
@@ -1,2 +1,9 @@
-class InvalidLuminousOpeningException(Exception):
-    pass
+class InvalidPhotometricFileFormatException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class InvalidLuminousOpeningException(InvalidPhotometricFileFormatException):
+    def __init__(self, value):
+        super().__init__("Invalid values for luminous opening geometry")
+

--- a/photometric_viewer/formats/ies.py
+++ b/photometric_viewer/formats/ies.py
@@ -1,6 +1,6 @@
 from typing import IO
 
-from photometric_viewer.formats.exceptions import InvalidLuminousOpeningException
+from photometric_viewer.formats.exceptions import InvalidLuminousOpeningException, InvalidPhotometricFileFormatException
 from photometric_viewer.model.photometry import Photometry, PhotometryMetadata, LuminousOpeningGeometry, Shape, \
     Lamps
 from photometric_viewer.model.units import LengthUnits
@@ -48,7 +48,9 @@ def create_luminous_opening(attributes):
 
 
 def import_from_file(f: IO):
-    ies_header = read_non_empty_line(f)
+    header = read_non_empty_line(f).strip()
+    if not header.upper().startswith("IESNA"):
+        raise InvalidPhotometricFileFormatException(f"{header} could not be recognized as a valid IESNA file header")
 
     metadata = {}
     next_line = read_non_empty_line(f)

--- a/photometric_viewer/main.py
+++ b/photometric_viewer/main.py
@@ -2,9 +2,6 @@ import os
 
 import gi
 
-from photometric_viewer.formats.ies import import_from_file
-from photometric_viewer.utils.gio import gio_file_stream
-
 gi.require_version(namespace='Gtk', version='4.0')
 gi.require_version(namespace='Adw', version='1')
 
@@ -39,13 +36,11 @@ class Application(Adw.Application):
     def do_shutdown(self):
         Adw.Application.do_shutdown(self)
 
-
     def do_open(self, *args, **kwargs):
         file: Gio.File = args[0][0]
-        with gio_file_stream(file) as f:
-            photometry = import_from_file(f)
-            self.win.open_photometry(photometry)
+        self.win.open_file(file)
         self.props.active_window.present()
+
 
 def run():
     app = Application()


### PR DESCRIPTION
Previously when an user tried to open an invalid photometric file, the application either did not start properly and remained opened in background without any application window (when opening via command line parameters) or just ignored the error silently (when using the open button).

In course of removing duplicated code, this PR also closes #41 