### PR TITLE
Use separate locale dir when running as flatpak

### DIFF
--- a/photometric_viewer/main.py
+++ b/photometric_viewer/main.py
@@ -14,11 +14,14 @@ import gettext
 
 APPLICATION_ID = 'io.github.dlippok.photometric-viewer'
 
+LOCALE_DIR = None
+if os.environ.get("container", None) == "flatpak":
+    LOCALE_DIR = "/app/share/locale"
+
+
 locale.setlocale(locale.LC_ALL, '')
-locale.bindtextdomain(APPLICATION_ID, None)
-gettext.install(APPLICATION_ID)
-
-
+locale.bindtextdomain(APPLICATION_ID, LOCALE_DIR)
+gettext.install(APPLICATION_ID, LOCALE_DIR)
 class Application(Adw.Application):
     def __init__(self):
         super().__init__(application_id=APPLICATION_ID,

--- a/photometric_viewer/main.py
+++ b/photometric_viewer/main.py
@@ -15,7 +15,7 @@ import gettext
 APPLICATION_ID = 'io.github.dlippok.photometric-viewer'
 
 locale.setlocale(locale.LC_ALL, '')
-locale.bindtextdomain(APPLICATION_ID)
+locale.bindtextdomain(APPLICATION_ID, None)
 gettext.install(APPLICATION_ID)
 
 


### PR DESCRIPTION
By default gettext does not recognize the locale directory `/app/share/locale` which is used by flatpak to distribute the translations. This change checks via env variable if Photometric Viewer runs als flatpak and if so, enforces the correct directory

See #9 