### PR TITLE
Configure photometric diagram

### DIFF
--- a/data/io.github.dlippok.photometric-viewer.gschema.xml
+++ b/data/io.github.dlippok.photometric-viewer.gschema.xml
@@ -45,5 +45,10 @@
             <summary>Display half spaces</summary>
             <description>Decides whether only the relevant half space or full 180 degrees of gamma values should be displayed.</description>
         </key>
+        <key type="s" name="diagram-theme">
+            <default>'Adwaita'</default>
+            <summary>Scheme of the photometric diagram</summary>
+            <description>Name of the scheme to use. If scheme with the specified name is not found, default will be used.</description>
+        </key>
     </schema>
 </schemalist>

--- a/data/io.github.dlippok.photometric-viewer.gschema.xml
+++ b/data/io.github.dlippok.photometric-viewer.gschema.xml
@@ -1,22 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <enum id="io.github.dlippok.photometric-viewer.length-units-enum">
-      <value nick="meters" value="1"/>
-      <value nick="centimeters" value="2"/>
-      <value nick="millimeters" value="3"/>
-      <value nick="feet" value="4"/>
-      <value nick="inches" value="5"/>
-  </enum>
-  <schema id="io.github.dlippok.photometric-viewer" path="/apps/io/github/dlippok/photometric-viewer/">
-      <key type="b" name="length-units-from-file">
-          <default>false</default>
-          <summary>Use length unit from photometric file</summary>
-          <description>Whenever applicable, display length the same units as used in the photometric file instead of the selected ones.</description>
-      </key>
-      <key enum="io.github.dlippok.photometric-viewer.length-units-enum" name="preferred-length-units">
-          <default>'meters'</default>
-          <summary>Preferred units to be used when displaying length values</summary>
-          <description>All length values from the photometric file will be converted to the selected unit when displaying in the UI.</description>
-      </key>
-  </schema>
+    <enum id="io.github.dlippok.photometric-viewer.length-units-enum">
+        <value nick="meters" value="1"/>
+        <value nick="centimeters" value="2"/>
+        <value nick="millimeters" value="3"/>
+        <value nick="feet" value="4"/>
+        <value nick="inches" value="5"/>
+    </enum>
+    <enum id="io.github.dlippok.photometric-viewer.diagram-style-enum">
+        <value nick="simple" value="1"/>
+        <value nick="detailed" value="2"/>
+    </enum>
+    <enum id="io.github.dlippok.photometric-viewer.snap-value-angles-to-enum">
+        <value nick="max-value" value="1"/>
+        <value nick="round-number" value="2"/>
+    </enum>
+    <enum id="io.github.dlippok.photometric-viewer.display-half-spaces-enum">
+        <value nick="both" value="1"/>
+        <value nick="only-relevant" value="2"/>
+    </enum>
+    <schema id="io.github.dlippok.photometric-viewer" path="/apps/io/github/dlippok/photometric-viewer/">
+        <key type="b" name="length-units-from-file">
+            <default>false</default>
+            <summary>Use length unit from photometric file</summary>
+            <description>Whenever applicable, display length the same units as used in the photometric file instead of the selected ones.</description>
+        </key>
+        <key enum="io.github.dlippok.photometric-viewer.length-units-enum" name="preferred-length-units">
+            <default>'meters'</default>
+            <summary>Preferred units to be used when displaying length values</summary>
+            <description>All length values from the photometric file will be converted to the selected unit when displaying in the UI.</description>
+        </key>
+        <key enum="io.github.dlippok.photometric-viewer.diagram-style-enum" name="diagram-style">
+            <default>'simple'</default>
+            <summary>Style of the displayed diagram</summary>
+            <description>Configures amount of details showed in the diagram.</description>
+        </key>
+        <key enum="io.github.dlippok.photometric-viewer.snap-value-angles-to-enum" name="snap-value-angles-to">
+            <default>'max-value'</default>
+            <summary>Snap values to</summary>
+            <description>Configures whether the guides with intensity values should be scaled to max value or the closest round number.</description>
+        </key>
+        <key enum="io.github.dlippok.photometric-viewer.display-half-spaces-enum" name="display-half-spaces">
+            <default>'only-relevant'</default>
+            <summary>Display half spaces</summary>
+            <description>Decides whether only the relevant half space or full 180 degrees of gamma values should be displayed.</description>
+        </key>
+    </schema>
 </schemalist>

--- a/data/translations/de/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
+++ b/data/translations/de/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 22:33+0200\n"
-"PO-Revision-Date: 2023-07-22 22:39+0200\n"
+"POT-Creation-Date: 2023-07-23 18:49+0200\n"
+"PO-Revision-Date: 2023-07-23 18:51+0200\n"
 "Last-Translator: DaLee <mail.dalee@gmail.com>\n"
 "Language-Team: German - Germany <mail.dalee@gmail.com>\n"
 "Language: de_DE\n"
@@ -39,6 +39,7 @@ msgstr ""
 "Wählen Sie eine C-Ebene oder einen Gamma-Winkel um die Werte anzuzeigen"
 
 #: photometric_viewer/gui/pages/content.py:34
+#: photometric_viewer/gui/dialogs/preferences.py:88
 #: photometric_viewer/gui/dialogs/preferences.py:87
 msgid "Photometric diagram"
 msgstr "Lichtverteilungskurve"
@@ -73,92 +74,116 @@ msgstr "Öffnen Sie eine Photometriedatei, um diese hier anzuzeigen"
 msgid "Photometric Viewer"
 msgstr "Photometriebetrachter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:13
 #: photometric_viewer/gui/dialogs/preferences.py:12
 #: photometric_viewer/gui/dialogs/preferences.py:18
 msgid "Application Settings"
 msgstr "Einstellungen"
 
+#: photometric_viewer/gui/dialogs/preferences.py:25
 #: photometric_viewer/gui/dialogs/preferences.py:24
 #: photometric_viewer/gui/dialogs/preferences.py:22
 msgid "Units"
 msgstr "Einheiten"
 
+#: photometric_viewer/gui/dialogs/preferences.py:26
 #: photometric_viewer/gui/dialogs/preferences.py:25
 #: photometric_viewer/gui/dialogs/preferences.py:23
 msgid "Measurement units displayed in the application"
 msgstr "Längeneinheiten für Anzeige in der Applikation"
 
+#: photometric_viewer/gui/dialogs/preferences.py:41
 #: photometric_viewer/gui/dialogs/preferences.py:40
 #: photometric_viewer/gui/dialogs/preferences.py:38
 msgid "Use units from photometric file"
 msgstr "Benutze Einheiten aus der Photometriedatei"
 
+#: photometric_viewer/gui/dialogs/preferences.py:55
 #: photometric_viewer/gui/dialogs/preferences.py:54
 #: photometric_viewer/gui/dialogs/preferences.py:52
 msgid "Preferred length units"
 msgstr "Bevorzugte Längeneinheiten"
 
+#: photometric_viewer/gui/dialogs/preferences.py:57
 #: photometric_viewer/gui/dialogs/preferences.py:56
 #: photometric_viewer/gui/dialogs/preferences.py:54
 msgid "Meters"
 msgstr "Meter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:58
 #: photometric_viewer/gui/dialogs/preferences.py:57
 #: photometric_viewer/gui/dialogs/preferences.py:55
 msgid "Centimeters"
 msgstr "Zentimeter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:59
 #: photometric_viewer/gui/dialogs/preferences.py:58
 #: photometric_viewer/gui/dialogs/preferences.py:56
 msgid "Millimeters"
 msgstr "Millimeter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:60
 #: photometric_viewer/gui/dialogs/preferences.py:59
 #: photometric_viewer/gui/dialogs/preferences.py:57
 msgid "Feet"
 msgstr "Fuß"
 
+#: photometric_viewer/gui/dialogs/preferences.py:61
 #: photometric_viewer/gui/dialogs/preferences.py:60
 #: photometric_viewer/gui/dialogs/preferences.py:58
 msgid "Inches"
 msgstr "Zoll"
 
+#: photometric_viewer/gui/dialogs/preferences.py:89
 #: photometric_viewer/gui/dialogs/preferences.py:88
 msgid "Apperance of light distribution diagram"
 msgstr "Aussehen der Lichtverteilungskurve"
 
+#: photometric_viewer/gui/dialogs/preferences.py:106
+msgid "Theme"
+msgstr "Design"
+
+#: photometric_viewer/gui/dialogs/preferences.py:129
 #: photometric_viewer/gui/dialogs/preferences.py:110
 msgid "Simple"
 msgstr "Einfach"
 
+#: photometric_viewer/gui/dialogs/preferences.py:135
 #: photometric_viewer/gui/dialogs/preferences.py:116
 msgid "Detailed"
 msgstr "Detaliert"
 
+#: photometric_viewer/gui/dialogs/preferences.py:143
 #: photometric_viewer/gui/dialogs/preferences.py:124
 msgid "Style"
 msgstr "Stil"
 
+#: photometric_viewer/gui/dialogs/preferences.py:162
 #: photometric_viewer/gui/dialogs/preferences.py:142
 msgid "Max value"
 msgstr "Größter Wert"
 
+#: photometric_viewer/gui/dialogs/preferences.py:168
 #: photometric_viewer/gui/dialogs/preferences.py:148
 msgid "Round number"
 msgstr "Runde Zahl"
 
+#: photometric_viewer/gui/dialogs/preferences.py:176
 #: photometric_viewer/gui/dialogs/preferences.py:156
 msgid "Snap guides to"
 msgstr "Richte Hilfslinien an"
 
+#: photometric_viewer/gui/dialogs/preferences.py:194
 #: photometric_viewer/gui/dialogs/preferences.py:174
 msgid "Both"
 msgstr "Beide"
 
+#: photometric_viewer/gui/dialogs/preferences.py:200
 #: photometric_viewer/gui/dialogs/preferences.py:180
 msgid "Only relevant"
 msgstr "Nur relevante"
 
+#: photometric_viewer/gui/dialogs/preferences.py:208
 #: photometric_viewer/gui/dialogs/preferences.py:188
 msgid "Display half spaces"
 msgstr "Halbräume"

--- a/data/translations/de/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
+++ b/data/translations/de/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
@@ -5,61 +5,163 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-15 23:29+0200\n"
-"PO-Revision-Date: 2023-07-15 23:29+0200\n"
+"POT-Creation-Date: 2023-07-22 22:33+0200\n"
+"PO-Revision-Date: 2023-07-22 22:39+0200\n"
 "Last-Translator: DaLee <mail.dalee@gmail.com>\n"
-"Language-Team: German <mail.dalee@gmail.com>\n"
-"Language: de\n"
+"Language-Team: German - Germany <mail.dalee@gmail.com>\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "X-Generator: Gtranslator 42.0\n"
 
+#: photometric_viewer/gui/pages/values.py:21
+msgid "C Plane"
+msgstr "C-Ebene"
+
+#: photometric_viewer/gui/pages/values.py:26
+msgid "Gamma angle"
+msgstr "Gamma-Winkel"
+
+#: photometric_viewer/gui/pages/values.py:57
+#: photometric_viewer/gui/pages/values.py:63
+msgid "Show all"
+msgstr "Alle anzeigen"
+
+#: photometric_viewer/gui/pages/values.py:95
+msgid "Too many values to display"
+msgstr "Zu viele Werte für die Anzeige"
+
+#: photometric_viewer/gui/pages/values.py:96
+msgid "Select a particular C plane or gamma angle to display the values"
+msgstr ""
+"Wählen Sie eine C-Ebene oder einen Gamma-Winkel um die Werte anzuzeigen"
+
+#: photometric_viewer/gui/pages/content.py:34
+#: photometric_viewer/gui/dialogs/preferences.py:87
+msgid "Photometric diagram"
+msgstr "Lichtverteilungskurve"
+
+#: photometric_viewer/gui/pages/content.py:37
+msgid "General information"
+msgstr "Allgemeine Informationen"
+
+#: photometric_viewer/gui/pages/content.py:40
+msgid "Photometric properties"
+msgstr "Photometrische Eigenschaften"
+
+#: photometric_viewer/gui/pages/content.py:43
+msgid "Geometry"
+msgstr "Geometrie"
+
+#: photometric_viewer/gui/pages/content.py:46
+msgid "Lamps and ballast"
+msgstr "Lampen und Vorschaltgeräte"
+
+#: photometric_viewer/gui/pages/empty.py:10
+msgid "No content"
+msgstr "Kein Inhalt"
+
+#: photometric_viewer/gui/pages/empty.py:11
+msgid "Open photometric file to display it here"
+msgstr "Öffnen Sie eine Photometriedatei, um diese hier anzuzeigen"
+
 #: photometric_viewer/gui/dialogs/about.py:7
-#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:73
+#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:71
+#: photometric_viewer/gui/window.py:73
 msgid "Photometric Viewer"
 msgstr "Photometriebetrachter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:12
 #: photometric_viewer/gui/dialogs/preferences.py:18
 msgid "Application Settings"
 msgstr "Einstellungen"
 
+#: photometric_viewer/gui/dialogs/preferences.py:24
 #: photometric_viewer/gui/dialogs/preferences.py:22
 msgid "Units"
 msgstr "Einheiten"
 
+#: photometric_viewer/gui/dialogs/preferences.py:25
 #: photometric_viewer/gui/dialogs/preferences.py:23
 msgid "Measurement units displayed in the application"
 msgstr "Längeneinheiten für Anzeige in der Applikation"
 
+#: photometric_viewer/gui/dialogs/preferences.py:40
 #: photometric_viewer/gui/dialogs/preferences.py:38
 msgid "Use units from photometric file"
 msgstr "Benutze Einheiten aus der Photometriedatei"
 
+#: photometric_viewer/gui/dialogs/preferences.py:54
 #: photometric_viewer/gui/dialogs/preferences.py:52
 msgid "Preferred length units"
 msgstr "Bevorzugte Längeneinheiten"
 
+#: photometric_viewer/gui/dialogs/preferences.py:56
 #: photometric_viewer/gui/dialogs/preferences.py:54
 msgid "Meters"
 msgstr "Meter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:57
 #: photometric_viewer/gui/dialogs/preferences.py:55
 msgid "Centimeters"
 msgstr "Zentimeter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:58
 #: photometric_viewer/gui/dialogs/preferences.py:56
 msgid "Millimeters"
 msgstr "Millimeter"
 
+#: photometric_viewer/gui/dialogs/preferences.py:59
 #: photometric_viewer/gui/dialogs/preferences.py:57
 msgid "Feet"
 msgstr "Fuß"
 
+#: photometric_viewer/gui/dialogs/preferences.py:60
 #: photometric_viewer/gui/dialogs/preferences.py:58
 msgid "Inches"
 msgstr "Zoll"
+
+#: photometric_viewer/gui/dialogs/preferences.py:88
+msgid "Apperance of light distribution diagram"
+msgstr "Aussehen der Lichtverteilungskurve"
+
+#: photometric_viewer/gui/dialogs/preferences.py:110
+msgid "Simple"
+msgstr "Einfach"
+
+#: photometric_viewer/gui/dialogs/preferences.py:116
+msgid "Detailed"
+msgstr "Detaliert"
+
+#: photometric_viewer/gui/dialogs/preferences.py:124
+msgid "Style"
+msgstr "Stil"
+
+#: photometric_viewer/gui/dialogs/preferences.py:142
+msgid "Max value"
+msgstr "Größter Wert"
+
+#: photometric_viewer/gui/dialogs/preferences.py:148
+msgid "Round number"
+msgstr "Runde Zahl"
+
+#: photometric_viewer/gui/dialogs/preferences.py:156
+msgid "Snap guides to"
+msgstr "Richte Hilfslinien an"
+
+#: photometric_viewer/gui/dialogs/preferences.py:174
+msgid "Both"
+msgstr "Beide"
+
+#: photometric_viewer/gui/dialogs/preferences.py:180
+msgid "Only relevant"
+msgstr "Nur relevante"
+
+#: photometric_viewer/gui/dialogs/preferences.py:188
+msgid "Display half spaces"
+msgstr "Halbräume"
 
 #: photometric_viewer/gui/dialogs/file_chooser.py:15
 msgid "All files"
@@ -113,122 +215,6 @@ msgstr "EULUMDAT (*.ldt)"
 msgid "All Files"
 msgstr "Alle Dateien"
 
-#: photometric_viewer/gui/pages/values.py:21
-msgid "C Plane"
-msgstr "C-Ebene"
-
-#: photometric_viewer/gui/pages/values.py:26
-msgid "Gamma angle"
-msgstr "Gamma-Winkel"
-
-#: photometric_viewer/gui/pages/values.py:57
-#: photometric_viewer/gui/pages/values.py:63
-msgid "Show all"
-msgstr "Alle anzeigen"
-
-#: photometric_viewer/gui/pages/values.py:95
-msgid "Too many values to display"
-msgstr "Zu viele Werte für die Anzeige"
-
-#: photometric_viewer/gui/pages/values.py:96
-msgid "Select a particular C plane or gamma angle to display the values"
-msgstr ""
-"Wählen Sie eine C-Ebene oder einen Gamma-Winkel um die Werte anzuzeigen"
-
-#: photometric_viewer/gui/pages/content.py:34
-msgid "Photometric diagram"
-msgstr "Lichtverteilungskurve"
-
-#: photometric_viewer/gui/pages/content.py:37
-msgid "General information"
-msgstr "Allgemeine Informationen"
-
-#: photometric_viewer/gui/pages/content.py:40
-msgid "Photometric properties"
-msgstr "Photometrische Eigenschaften"
-
-#: photometric_viewer/gui/pages/content.py:43
-msgid "Geometry"
-msgstr "Geometrie"
-
-#: photometric_viewer/gui/pages/content.py:46
-msgid "Lamps and ballast"
-msgstr "Lampen und Vorschaltgeräte"
-
-#: photometric_viewer/gui/pages/empty.py:10
-msgid "No content"
-msgstr "Kein Inhalt"
-
-#: photometric_viewer/gui/pages/empty.py:11
-msgid "Open photometric file to display it here"
-msgstr "Öffnen Sie eine Photometriedatei, um diese hier anzuzeigen"
-
-#: photometric_viewer/gui/window.py:38 photometric_viewer/gui/window.py:36
-#: photometric_viewer/gui/window.py:34
-msgid ""
-"Settings schema could not be loaded. Selected settings will be lost on "
-"restart"
-msgstr ""
-"Schema für Einstellungen könnte nicht geladen werden. Eingestellte Werte "
-"werden nach dem Programmende verworfen"
-
-#: photometric_viewer/gui/window.py:46 photometric_viewer/gui/window.py:47
-#: photometric_viewer/gui/window.py:45 photometric_viewer/gui/window.py:44
-#: photometric_viewer/gui/window.py:42
-msgid "Photometry"
-msgstr "Photometrie"
-
-#: photometric_viewer/gui/window.py:50 photometric_viewer/gui/window.py:51
-#: photometric_viewer/gui/window.py:49 photometric_viewer/gui/window.py:48
-#: photometric_viewer/gui/window.py:46
-msgid "Source"
-msgstr "Quelle"
-
-#: photometric_viewer/gui/window.py:55 photometric_viewer/gui/window.py:56
-#: photometric_viewer/gui/window.py:54 photometric_viewer/gui/window.py:53
-#: photometric_viewer/gui/window.py:51
-msgid "Intensity Values"
-msgstr "Lichtstärken"
-
-#: photometric_viewer/gui/window.py:63 photometric_viewer/gui/window.py:64
-#: photometric_viewer/gui/window.py:62 photometric_viewer/gui/window.py:61
-#: photometric_viewer/gui/window.py:59
-msgid "Dismiss"
-msgstr "Schließen"
-
-#: photometric_viewer/gui/window.py:67 photometric_viewer/gui/window.py:68
-#: photometric_viewer/gui/window.py:66 photometric_viewer/gui/window.py:65
-#: photometric_viewer/gui/window.py:64 photometric_viewer/gui/window.py:62
-msgid "Open"
-msgstr "Öffnen"
-
-#: photometric_viewer/gui/window.py:147 photometric_viewer/gui/window.py:159
-#: photometric_viewer/gui/window.py:174 photometric_viewer/gui/window.py:139
-#: photometric_viewer/gui/window.py:151 photometric_viewer/gui/window.py:149
-msgid "Exported as {}"
-msgstr "Exportiert als {}"
-
-#: photometric_viewer/gui/window.py:196 photometric_viewer/gui/window.py:191
-#: photometric_viewer/gui/window.py:168 photometric_viewer/gui/window.py:165
-#: photometric_viewer/gui/window.py:158 photometric_viewer/gui/window.py:125
-msgid "Invalid content of photometric file {}"
-msgstr "Ungültiger Inhalt in der Photometriedatei {}"
-
-#: photometric_viewer/gui/window.py:199 photometric_viewer/gui/window.py:194
-#: photometric_viewer/gui/window.py:171 photometric_viewer/gui/window.py:168
-#: photometric_viewer/gui/window.py:161 photometric_viewer/gui/window.py:128
-msgid "Could not open {}"
-msgstr "Datei {} könnte nich geöffnet werden"
-
-#: photometric_viewer/gui/widgets/common/property_list.py:26
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: photometric_viewer/gui/widgets/content/properties.py:16
-#: photometric_viewer/gui/pages/content.py:49
-msgid "Additional properties"
-msgstr "Zusätzliche Informationen"
-
 #: photometric_viewer/gui/widgets/content/general.py:15
 #: photometric_viewer/gui/widgets/content/general.py:12
 msgid "Catalog Number"
@@ -274,50 +260,6 @@ msgstr "Linienquelle"
 msgid "Point source with any other symmetry"
 msgstr "Punktquelle mit anderer Symmetrie"
 
-#: photometric_viewer/gui/widgets/content/lamps.py:35
-msgid "Number of lamps"
-msgstr "Anzahl der Lampen"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:36
-msgid "Lamp"
-msgstr "Lampe"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:37
-msgid "Lamp catalog no."
-msgstr "Katalognummer der Lampe"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:38
-msgid "Color"
-msgstr "Lichtfarbe"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:39
-msgid "Color Rendering Index (CRI)"
-msgstr "Farbwiedergabeindex"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:40
-msgid "Wattage"
-msgstr "Leistung"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:43
-msgid "Initial rating per lamp"
-msgstr "Ursprünglicher Lichtstrom pro Lampe"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:45
-msgid "Lamp position"
-msgstr "Position der Lampe"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:46
-msgid "Ballast"
-msgstr "Vorschaltgerät"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:47
-msgid "Ballast catalog no."
-msgstr "Katalognummer des Vorschaltgerätes"
-
-#: photometric_viewer/gui/widgets/content/lamps.py:49
-msgid "Lamp {}"
-msgstr "Lampe {}"
-
 #: photometric_viewer/gui/widgets/content/photometry.py:20
 #: photometric_viewer/gui/widgets/content/photometry.py:17
 msgid "Light output ratio"
@@ -332,6 +274,11 @@ msgstr "Unterer halbräumlicher Lichtstromanteil"
 #: photometric_viewer/formats/ldt.py:165
 msgid "Conversion factor for luminous intensities"
 msgstr "Berechnungsfaktor für Lichtstärken"
+
+#: photometric_viewer/gui/widgets/content/properties.py:16
+#: photometric_viewer/gui/pages/content.py:49
+msgid "Additional properties"
+msgstr "Zusätzliche Informationen"
 
 #: photometric_viewer/gui/widgets/content/geometry.py:60
 #: photometric_viewer/gui/widgets/content/geometry.py:59
@@ -413,6 +360,115 @@ msgstr "Abmessungen der Lichtaustrittfläche"
 #: photometric_viewer/gui/widgets/content/geometry.py:98
 msgid "Luminous opening height"
 msgstr "Höhe der Lichtaustrittfläche"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:35
+msgid "Number of lamps"
+msgstr "Anzahl der Lampen"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:36
+msgid "Lamp"
+msgstr "Lampe"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:37
+msgid "Lamp catalog no."
+msgstr "Katalognummer der Lampe"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:38
+msgid "Color"
+msgstr "Lichtfarbe"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:39
+msgid "Color Rendering Index (CRI)"
+msgstr "Farbwiedergabeindex"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:40
+msgid "Wattage"
+msgstr "Leistung"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:43
+msgid "Initial rating per lamp"
+msgstr "Ursprünglicher Lichtstrom pro Lampe"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:45
+msgid "Lamp position"
+msgstr "Position der Lampe"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:46
+msgid "Ballast"
+msgstr "Vorschaltgerät"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:47
+msgid "Ballast catalog no."
+msgstr "Katalognummer des Vorschaltgerätes"
+
+#: photometric_viewer/gui/widgets/content/lamps.py:49
+msgid "Lamp {}"
+msgstr "Lampe {}"
+
+#: photometric_viewer/gui/widgets/common/property_list.py:26
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: photometric_viewer/gui/window.py:44 photometric_viewer/gui/window.py:46
+#: photometric_viewer/gui/window.py:47 photometric_viewer/gui/window.py:45
+#: photometric_viewer/gui/window.py:42
+msgid "Photometry"
+msgstr "Photometrie"
+
+#: photometric_viewer/gui/window.py:48 photometric_viewer/gui/window.py:50
+#: photometric_viewer/gui/window.py:51 photometric_viewer/gui/window.py:49
+#: photometric_viewer/gui/window.py:46
+msgid "Source"
+msgstr "Quelle"
+
+#: photometric_viewer/gui/window.py:53 photometric_viewer/gui/window.py:55
+#: photometric_viewer/gui/window.py:56 photometric_viewer/gui/window.py:54
+#: photometric_viewer/gui/window.py:51
+msgid "Intensity Values"
+msgstr "Lichtstärken"
+
+#: photometric_viewer/gui/window.py:61 photometric_viewer/gui/window.py:63
+#: photometric_viewer/gui/window.py:64 photometric_viewer/gui/window.py:62
+#: photometric_viewer/gui/window.py:59
+msgid "Dismiss"
+msgstr "Schließen"
+
+#: photometric_viewer/gui/window.py:65 photometric_viewer/gui/window.py:67
+#: photometric_viewer/gui/window.py:68 photometric_viewer/gui/window.py:66
+#: photometric_viewer/gui/window.py:64 photometric_viewer/gui/window.py:62
+msgid "Open"
+msgstr "Öffnen"
+
+#: photometric_viewer/gui/window.py:98 photometric_viewer/gui/window.py:38
+#: photometric_viewer/gui/window.py:36 photometric_viewer/gui/window.py:34
+msgid ""
+"Settings schema could not be loaded. Selected settings will be lost on "
+"restart"
+msgstr ""
+"Schema für Einstellungen könnte nicht geladen werden. Eingestellte Werte "
+"werden nach dem Programmende verworfen"
+
+#: photometric_viewer/gui/window.py:148 photometric_viewer/gui/window.py:160
+#: photometric_viewer/gui/window.py:175 photometric_viewer/gui/window.py:147
+#: photometric_viewer/gui/window.py:159 photometric_viewer/gui/window.py:174
+#: photometric_viewer/gui/window.py:139 photometric_viewer/gui/window.py:151
+#: photometric_viewer/gui/window.py:149
+msgid "Exported as {}"
+msgstr "Exportiert als {}"
+
+#: photometric_viewer/gui/window.py:197 photometric_viewer/gui/window.py:196
+#: photometric_viewer/gui/window.py:191 photometric_viewer/gui/window.py:168
+#: photometric_viewer/gui/window.py:165 photometric_viewer/gui/window.py:158
+#: photometric_viewer/gui/window.py:125
+msgid "Invalid content of photometric file {}"
+msgstr "Ungültiger Inhalt in der Photometriedatei {}"
+
+#: photometric_viewer/gui/window.py:200 photometric_viewer/gui/window.py:199
+#: photometric_viewer/gui/window.py:194 photometric_viewer/gui/window.py:171
+#: photometric_viewer/gui/window.py:168 photometric_viewer/gui/window.py:161
+#: photometric_viewer/gui/window.py:128
+msgid "Could not open {}"
+msgstr "Datei {} könnte nich geöffnet werden"
 
 #: photometric_viewer/gui/dialogs/about.py:7
 msgid "Photomertic Viewer"

--- a/data/translations/io.github.dlippok.photometric-viewer.pot
+++ b/data/translations/io.github.dlippok.photometric-viewer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-22 22:33+0200\n"
+"POT-Creation-Date: 2023-07-23 18:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,6 +39,7 @@ msgid "Select a particular C plane or gamma angle to display the values"
 msgstr ""
 
 #: photometric_viewer/gui/pages/content.py:34
+#: photometric_viewer/gui/dialogs/preferences.py:88
 #: photometric_viewer/gui/dialogs/preferences.py:87
 msgid "Photometric diagram"
 msgstr ""
@@ -73,92 +74,116 @@ msgstr ""
 msgid "Photometric Viewer"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:13
 #: photometric_viewer/gui/dialogs/preferences.py:12
 #: photometric_viewer/gui/dialogs/preferences.py:18
 msgid "Application Settings"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:25
 #: photometric_viewer/gui/dialogs/preferences.py:24
 #: photometric_viewer/gui/dialogs/preferences.py:22
 msgid "Units"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:26
 #: photometric_viewer/gui/dialogs/preferences.py:25
 #: photometric_viewer/gui/dialogs/preferences.py:23
 msgid "Measurement units displayed in the application"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:41
 #: photometric_viewer/gui/dialogs/preferences.py:40
 #: photometric_viewer/gui/dialogs/preferences.py:38
 msgid "Use units from photometric file"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:55
 #: photometric_viewer/gui/dialogs/preferences.py:54
 #: photometric_viewer/gui/dialogs/preferences.py:52
 msgid "Preferred length units"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:57
 #: photometric_viewer/gui/dialogs/preferences.py:56
 #: photometric_viewer/gui/dialogs/preferences.py:54
 msgid "Meters"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:58
 #: photometric_viewer/gui/dialogs/preferences.py:57
 #: photometric_viewer/gui/dialogs/preferences.py:55
 msgid "Centimeters"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:59
 #: photometric_viewer/gui/dialogs/preferences.py:58
 #: photometric_viewer/gui/dialogs/preferences.py:56
 msgid "Millimeters"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:60
 #: photometric_viewer/gui/dialogs/preferences.py:59
 #: photometric_viewer/gui/dialogs/preferences.py:57
 msgid "Feet"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:61
 #: photometric_viewer/gui/dialogs/preferences.py:60
 #: photometric_viewer/gui/dialogs/preferences.py:58
 msgid "Inches"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:89
 #: photometric_viewer/gui/dialogs/preferences.py:88
 msgid "Apperance of light distribution diagram"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:106
+msgid "Theme"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:129
 #: photometric_viewer/gui/dialogs/preferences.py:110
 msgid "Simple"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:135
 #: photometric_viewer/gui/dialogs/preferences.py:116
 msgid "Detailed"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:143
 #: photometric_viewer/gui/dialogs/preferences.py:124
 msgid "Style"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:162
 #: photometric_viewer/gui/dialogs/preferences.py:142
 msgid "Max value"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:168
 #: photometric_viewer/gui/dialogs/preferences.py:148
 msgid "Round number"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:176
 #: photometric_viewer/gui/dialogs/preferences.py:156
 msgid "Snap guides to"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:194
 #: photometric_viewer/gui/dialogs/preferences.py:174
 msgid "Both"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:200
 #: photometric_viewer/gui/dialogs/preferences.py:180
 msgid "Only relevant"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:208
 #: photometric_viewer/gui/dialogs/preferences.py:188
 msgid "Display half spaces"
 msgstr ""

--- a/data/translations/io.github.dlippok.photometric-viewer.pot
+++ b/data/translations/io.github.dlippok.photometric-viewer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-15 23:29+0200\n"
+"POT-Creation-Date: 2023-07-22 22:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,49 +17,150 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: photometric_viewer/gui/pages/values.py:21
+msgid "C Plane"
+msgstr ""
+
+#: photometric_viewer/gui/pages/values.py:26
+msgid "Gamma angle"
+msgstr ""
+
+#: photometric_viewer/gui/pages/values.py:57
+#: photometric_viewer/gui/pages/values.py:63
+msgid "Show all"
+msgstr ""
+
+#: photometric_viewer/gui/pages/values.py:95
+msgid "Too many values to display"
+msgstr ""
+
+#: photometric_viewer/gui/pages/values.py:96
+msgid "Select a particular C plane or gamma angle to display the values"
+msgstr ""
+
+#: photometric_viewer/gui/pages/content.py:34
+#: photometric_viewer/gui/dialogs/preferences.py:87
+msgid "Photometric diagram"
+msgstr ""
+
+#: photometric_viewer/gui/pages/content.py:37
+msgid "General information"
+msgstr ""
+
+#: photometric_viewer/gui/pages/content.py:40
+msgid "Photometric properties"
+msgstr ""
+
+#: photometric_viewer/gui/pages/content.py:43
+msgid "Geometry"
+msgstr ""
+
+#: photometric_viewer/gui/pages/content.py:46
+msgid "Lamps and ballast"
+msgstr ""
+
+#: photometric_viewer/gui/pages/empty.py:10
+msgid "No content"
+msgstr ""
+
+#: photometric_viewer/gui/pages/empty.py:11
+msgid "Open photometric file to display it here"
+msgstr ""
+
 #: photometric_viewer/gui/dialogs/about.py:7
-#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:73
+#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:71
+#: photometric_viewer/gui/window.py:73
 msgid "Photometric Viewer"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:12
 #: photometric_viewer/gui/dialogs/preferences.py:18
 msgid "Application Settings"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:24
 #: photometric_viewer/gui/dialogs/preferences.py:22
 msgid "Units"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:25
 #: photometric_viewer/gui/dialogs/preferences.py:23
 msgid "Measurement units displayed in the application"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:40
 #: photometric_viewer/gui/dialogs/preferences.py:38
 msgid "Use units from photometric file"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:54
 #: photometric_viewer/gui/dialogs/preferences.py:52
 msgid "Preferred length units"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:56
 #: photometric_viewer/gui/dialogs/preferences.py:54
 msgid "Meters"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:57
 #: photometric_viewer/gui/dialogs/preferences.py:55
 msgid "Centimeters"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:58
 #: photometric_viewer/gui/dialogs/preferences.py:56
 msgid "Millimeters"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:59
 #: photometric_viewer/gui/dialogs/preferences.py:57
 msgid "Feet"
 msgstr ""
 
+#: photometric_viewer/gui/dialogs/preferences.py:60
 #: photometric_viewer/gui/dialogs/preferences.py:58
 msgid "Inches"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:88
+msgid "Apperance of light distribution diagram"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:110
+msgid "Simple"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:116
+msgid "Detailed"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:124
+msgid "Style"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:142
+msgid "Max value"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:148
+msgid "Round number"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:156
+msgid "Snap guides to"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:174
+msgid "Both"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:180
+msgid "Only relevant"
+msgstr ""
+
+#: photometric_viewer/gui/dialogs/preferences.py:188
+msgid "Display half spaces"
 msgstr ""
 
 #: photometric_viewer/gui/dialogs/file_chooser.py:15
@@ -114,119 +215,6 @@ msgstr ""
 msgid "All Files"
 msgstr ""
 
-#: photometric_viewer/gui/pages/values.py:21
-msgid "C Plane"
-msgstr ""
-
-#: photometric_viewer/gui/pages/values.py:26
-msgid "Gamma angle"
-msgstr ""
-
-#: photometric_viewer/gui/pages/values.py:57
-#: photometric_viewer/gui/pages/values.py:63
-msgid "Show all"
-msgstr ""
-
-#: photometric_viewer/gui/pages/values.py:95
-msgid "Too many values to display"
-msgstr ""
-
-#: photometric_viewer/gui/pages/values.py:96
-msgid "Select a particular C plane or gamma angle to display the values"
-msgstr ""
-
-#: photometric_viewer/gui/pages/content.py:34
-msgid "Photometric diagram"
-msgstr ""
-
-#: photometric_viewer/gui/pages/content.py:37
-msgid "General information"
-msgstr ""
-
-#: photometric_viewer/gui/pages/content.py:40
-msgid "Photometric properties"
-msgstr ""
-
-#: photometric_viewer/gui/pages/content.py:43
-msgid "Geometry"
-msgstr ""
-
-#: photometric_viewer/gui/pages/content.py:46
-msgid "Lamps and ballast"
-msgstr ""
-
-#: photometric_viewer/gui/pages/empty.py:10
-msgid "No content"
-msgstr ""
-
-#: photometric_viewer/gui/pages/empty.py:11
-msgid "Open photometric file to display it here"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:38 photometric_viewer/gui/window.py:36
-#: photometric_viewer/gui/window.py:34
-msgid ""
-"Settings schema could not be loaded. Selected settings will be lost on "
-"restart"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:46 photometric_viewer/gui/window.py:47
-#: photometric_viewer/gui/window.py:45 photometric_viewer/gui/window.py:44
-#: photometric_viewer/gui/window.py:42
-msgid "Photometry"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:50 photometric_viewer/gui/window.py:51
-#: photometric_viewer/gui/window.py:49 photometric_viewer/gui/window.py:48
-#: photometric_viewer/gui/window.py:46
-msgid "Source"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:55 photometric_viewer/gui/window.py:56
-#: photometric_viewer/gui/window.py:54 photometric_viewer/gui/window.py:53
-#: photometric_viewer/gui/window.py:51
-msgid "Intensity Values"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:63 photometric_viewer/gui/window.py:64
-#: photometric_viewer/gui/window.py:62 photometric_viewer/gui/window.py:61
-#: photometric_viewer/gui/window.py:59
-msgid "Dismiss"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:67 photometric_viewer/gui/window.py:68
-#: photometric_viewer/gui/window.py:66 photometric_viewer/gui/window.py:65
-#: photometric_viewer/gui/window.py:64 photometric_viewer/gui/window.py:62
-msgid "Open"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:147 photometric_viewer/gui/window.py:159
-#: photometric_viewer/gui/window.py:174 photometric_viewer/gui/window.py:139
-#: photometric_viewer/gui/window.py:151 photometric_viewer/gui/window.py:149
-msgid "Exported as {}"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:196 photometric_viewer/gui/window.py:191
-#: photometric_viewer/gui/window.py:168 photometric_viewer/gui/window.py:165
-#: photometric_viewer/gui/window.py:158 photometric_viewer/gui/window.py:125
-msgid "Invalid content of photometric file {}"
-msgstr ""
-
-#: photometric_viewer/gui/window.py:199 photometric_viewer/gui/window.py:194
-#: photometric_viewer/gui/window.py:171 photometric_viewer/gui/window.py:168
-#: photometric_viewer/gui/window.py:161 photometric_viewer/gui/window.py:128
-msgid "Could not open {}"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/common/property_list.py:26
-msgid "Unknown"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/properties.py:16
-#: photometric_viewer/gui/pages/content.py:49
-msgid "Additional properties"
-msgstr ""
-
 #: photometric_viewer/gui/widgets/content/general.py:15
 #: photometric_viewer/gui/widgets/content/general.py:12
 msgid "Catalog Number"
@@ -272,50 +260,6 @@ msgstr ""
 msgid "Point source with any other symmetry"
 msgstr ""
 
-#: photometric_viewer/gui/widgets/content/lamps.py:35
-msgid "Number of lamps"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:36
-msgid "Lamp"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:37
-msgid "Lamp catalog no."
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:38
-msgid "Color"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:39
-msgid "Color Rendering Index (CRI)"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:40
-msgid "Wattage"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:43
-msgid "Initial rating per lamp"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:45
-msgid "Lamp position"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:46
-msgid "Ballast"
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:47
-msgid "Ballast catalog no."
-msgstr ""
-
-#: photometric_viewer/gui/widgets/content/lamps.py:49
-msgid "Lamp {}"
-msgstr ""
-
 #: photometric_viewer/gui/widgets/content/photometry.py:20
 #: photometric_viewer/gui/widgets/content/photometry.py:17
 msgid "Light output ratio"
@@ -329,6 +273,11 @@ msgstr ""
 #: photometric_viewer/gui/widgets/content/photometry.py:22
 #: photometric_viewer/formats/ldt.py:165
 msgid "Conversion factor for luminous intensities"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/properties.py:16
+#: photometric_viewer/gui/pages/content.py:49
+msgid "Additional properties"
 msgstr ""
 
 #: photometric_viewer/gui/widgets/content/geometry.py:60
@@ -410,6 +359,113 @@ msgstr ""
 
 #: photometric_viewer/gui/widgets/content/geometry.py:98
 msgid "Luminous opening height"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:35
+msgid "Number of lamps"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:36
+msgid "Lamp"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:37
+msgid "Lamp catalog no."
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:38
+msgid "Color"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:39
+msgid "Color Rendering Index (CRI)"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:40
+msgid "Wattage"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:43
+msgid "Initial rating per lamp"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:45
+msgid "Lamp position"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:46
+msgid "Ballast"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:47
+msgid "Ballast catalog no."
+msgstr ""
+
+#: photometric_viewer/gui/widgets/content/lamps.py:49
+msgid "Lamp {}"
+msgstr ""
+
+#: photometric_viewer/gui/widgets/common/property_list.py:26
+msgid "Unknown"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:44 photometric_viewer/gui/window.py:46
+#: photometric_viewer/gui/window.py:47 photometric_viewer/gui/window.py:45
+#: photometric_viewer/gui/window.py:42
+msgid "Photometry"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:48 photometric_viewer/gui/window.py:50
+#: photometric_viewer/gui/window.py:51 photometric_viewer/gui/window.py:49
+#: photometric_viewer/gui/window.py:46
+msgid "Source"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:53 photometric_viewer/gui/window.py:55
+#: photometric_viewer/gui/window.py:56 photometric_viewer/gui/window.py:54
+#: photometric_viewer/gui/window.py:51
+msgid "Intensity Values"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:61 photometric_viewer/gui/window.py:63
+#: photometric_viewer/gui/window.py:64 photometric_viewer/gui/window.py:62
+#: photometric_viewer/gui/window.py:59
+msgid "Dismiss"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:65 photometric_viewer/gui/window.py:67
+#: photometric_viewer/gui/window.py:68 photometric_viewer/gui/window.py:66
+#: photometric_viewer/gui/window.py:64 photometric_viewer/gui/window.py:62
+msgid "Open"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:98 photometric_viewer/gui/window.py:38
+#: photometric_viewer/gui/window.py:36 photometric_viewer/gui/window.py:34
+msgid ""
+"Settings schema could not be loaded. Selected settings will be lost on "
+"restart"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:148 photometric_viewer/gui/window.py:160
+#: photometric_viewer/gui/window.py:175 photometric_viewer/gui/window.py:147
+#: photometric_viewer/gui/window.py:159 photometric_viewer/gui/window.py:174
+#: photometric_viewer/gui/window.py:139 photometric_viewer/gui/window.py:151
+#: photometric_viewer/gui/window.py:149
+msgid "Exported as {}"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:197 photometric_viewer/gui/window.py:196
+#: photometric_viewer/gui/window.py:191 photometric_viewer/gui/window.py:168
+#: photometric_viewer/gui/window.py:165 photometric_viewer/gui/window.py:158
+#: photometric_viewer/gui/window.py:125
+msgid "Invalid content of photometric file {}"
+msgstr ""
+
+#: photometric_viewer/gui/window.py:200 photometric_viewer/gui/window.py:199
+#: photometric_viewer/gui/window.py:194 photometric_viewer/gui/window.py:171
+#: photometric_viewer/gui/window.py:168 photometric_viewer/gui/window.py:161
+#: photometric_viewer/gui/window.py:128
+msgid "Could not open {}"
 msgstr ""
 
 #: photometric_viewer/gui/dialogs/about.py:7

--- a/photometric_viewer/gui/dialogs/preferences.py
+++ b/photometric_viewer/gui/dialogs/preferences.py
@@ -1,23 +1,25 @@
 from gi.repository import Adw, Gtk
-from gi.repository.Gtk import ListBox, Box, Orientation, Label, SelectionMode
+from gi.repository.Gtk import ListBox, Box, Orientation, Label, SelectionMode, ToggleButton
 
-from photometric_viewer.model.settings import Settings
+from photometric_viewer.model.settings import Settings, DiagramStyle, SnapValueAnglesTo, DisplayHalfSpaces
 from photometric_viewer.model.units import LengthUnits
 
 
 class PreferencesWindow(Adw.PreferencesWindow):
     def __init__(self, settings: Settings, on_update_settings, **kwargs):
         super().__init__(**kwargs)
+        self.page = Adw.PreferencesPage(
+            title=_("Application Settings"),
+        )
+        self.add(self.page)
+
         self.set_search_enabled(False)
         self.settings = settings
         self.on_update_settings = on_update_settings
-        self._add_units_page()
+        self._add_units_settings_group()
+        self._add_curve_settings_group()
 
-    def _add_units_page(self):
-        page = Adw.PreferencesPage(
-            title=_("Application Settings"),
-        )
-
+    def _add_units_settings_group(self):
         units_group = Adw.PreferencesGroup(
             title=_("Units"),
             description=_("Measurement units displayed in the application")
@@ -78,8 +80,118 @@ class PreferencesWindow(Adw.PreferencesWindow):
         units_group_list.append(self.preferred_units_box)
         units_group.add(units_group_list)
 
-        page.add(units_group)
-        self.add(page)
+        self.page.add(units_group)
+
+    def _add_curve_settings_group(self):
+        curve_settings_group = Adw.PreferencesGroup(
+            title=_("Photometric diagram"),
+            description=_("Apperance of light distribution diagram")
+        )
+
+        curve_settings_list = ListBox(
+            css_classes=["boxed-list"],
+            selection_mode=SelectionMode.NONE
+        )
+
+        curve_style_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            spacing=4,
+            margin_start=16,
+            margin_end=16,
+            margin_top=16,
+            margin_bottom=16
+        )
+        curve_style_buttons_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            css_classes=["linked"]
+        )
+
+        style_simple_button = ToggleButton(
+            label=_("Simple"),
+            active=self.settings.diagram_style == DiagramStyle.SIMPLE
+        )
+        style_simple_button.connect("toggled", self.curve_style_simple_toggled)
+
+        style_detailed_button = ToggleButton(
+            label=_("Detailed"),
+            group=style_simple_button,
+            active=self.settings.diagram_style == DiagramStyle.DETAILED
+        )
+        style_detailed_button.connect("toggled", self.curve_style_detailed_toggled)
+
+        curve_style_buttons_box.append(style_simple_button)
+        curve_style_buttons_box.append(style_detailed_button)
+        curve_style_box.append(Label(label=_("Style"), hexpand=True, xalign=0))
+        curve_style_box.append(curve_style_buttons_box)
+        curve_settings_list.append(curve_style_box)
+
+        snap_values_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            spacing=4,
+            margin_start=16,
+            margin_end=16,
+            margin_top=16,
+            margin_bottom=16
+        )
+        snap_values_buttons_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            css_classes=["linked"]
+        )
+
+        snap_max_value_button = ToggleButton(
+            label=_("Max value"),
+            active=self.settings.snap_value_angles_to == SnapValueAnglesTo.MAX_VALUE
+        )
+        snap_max_value_button.connect("toggled", self.snap_max_value_toggled)
+
+        snap_round_value_button = ToggleButton(
+            label=_("Round number"),
+            group=snap_max_value_button,
+            active=self.settings.snap_value_angles_to == SnapValueAnglesTo.ROUND_NUMBER
+        )
+        snap_round_value_button.connect("toggled", self.snap_round_value_toggled)
+
+        snap_values_buttons_box.append(snap_max_value_button)
+        snap_values_buttons_box.append(snap_round_value_button)
+        snap_values_box.append(Label(label=_("Snap guides to"), hexpand=True, xalign=0))
+        snap_values_box.append(snap_values_buttons_box)
+        curve_settings_list.append(snap_values_box)
+
+        display_half_spaces_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            spacing=4,
+            margin_start=16,
+            margin_end=16,
+            margin_top=16,
+            margin_bottom=16
+        )
+        display_half_spaces_buttons_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            css_classes=["linked"]
+        )
+
+        display_half_spaces_both_button = ToggleButton(
+            label=_("Both"),
+            active=self.settings.display_half_spaces == DisplayHalfSpaces.BOTH
+        )
+        display_half_spaces_both_button.connect("toggled", self.display_half_spaces_both_toggled)
+
+        display_half_spaces_relevant_button = ToggleButton(
+            label=_("Only relevant"),
+            group=display_half_spaces_both_button,
+            active=self.settings.display_half_spaces == DisplayHalfSpaces.ONLY_RELEVANT
+        )
+        display_half_spaces_relevant_button.connect("toggled", self.display_half_spaces_relevant_toggled)
+
+        display_half_spaces_buttons_box.append(display_half_spaces_both_button)
+        display_half_spaces_buttons_box.append(display_half_spaces_relevant_button)
+        display_half_spaces_box.append(Label(label=_("Display half spaces"), hexpand=True, xalign=0))
+        display_half_spaces_box.append(display_half_spaces_buttons_box)
+        curve_settings_list.append(display_half_spaces_box)
+
+        curve_settings_group.add(curve_settings_list)
+
+        self.page.add(curve_settings_group)
 
     def preferred_unit_changed(self, *args):
         match self.preferred_units_dropdown.get_selected():
@@ -99,6 +211,36 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.settings.length_units_from_file = state
         self.preferred_units_box.set_sensitive(not state)
         self.update()
+
+    def curve_style_simple_toggled(self, widget: ToggleButton, *args):
+        if widget.get_active():
+            self.settings.diagram_style = DiagramStyle.SIMPLE
+            self.update()
+
+    def curve_style_detailed_toggled(self, widget: ToggleButton, *args):
+        if widget.get_active():
+            self.settings.diagram_style = DiagramStyle.DETAILED
+            self.update()
+
+    def snap_max_value_toggled(self, widget: ToggleButton, *args):
+        if widget.get_active():
+            self.settings.snap_value_angles_to = SnapValueAnglesTo.MAX_VALUE
+            self.update()
+
+    def snap_round_value_toggled(self, widget: ToggleButton, *args):
+        if widget.get_active():
+            self.settings.snap_value_angles_to = SnapValueAnglesTo.ROUND_NUMBER
+            self.update()
+
+    def display_half_spaces_both_toggled(self, widget: ToggleButton, *args):
+        if widget.get_active():
+            self.settings.display_half_spaces = DisplayHalfSpaces.BOTH
+            self.update()
+
+    def display_half_spaces_relevant_toggled(self, widget: ToggleButton, *args):
+        if widget.get_active():
+            self.settings.display_half_spaces = DisplayHalfSpaces.ONLY_RELEVANT
+            self.update()
 
     def update(self):
         self.on_update_settings()

--- a/photometric_viewer/gui/dialogs/preferences.py
+++ b/photometric_viewer/gui/dialogs/preferences.py
@@ -3,6 +3,7 @@ from gi.repository.Gtk import ListBox, Box, Orientation, Label, SelectionMode, T
 
 from photometric_viewer.model.settings import Settings, DiagramStyle, SnapValueAnglesTo, DisplayHalfSpaces
 from photometric_viewer.model.units import LengthUnits
+from photometric_viewer.utils import plotter_themes
 
 
 class PreferencesWindow(Adw.PreferencesWindow):
@@ -93,6 +94,24 @@ class PreferencesWindow(Adw.PreferencesWindow):
             selection_mode=SelectionMode.NONE
         )
 
+        self.diagram_theme_box = Box(
+            orientation=Orientation.HORIZONTAL,
+            spacing=4,
+            margin_start=16,
+            margin_end=16,
+            margin_top=16,
+            margin_bottom=16,
+            sensitive=not self.settings.length_units_from_file
+        )
+        self.diagram_theme_box.append(Label(label=_("Theme"), hexpand=True, xalign=0))
+        self.diagram_theme_dropdown: Gtk.DropDown = Gtk.DropDown.new_from_strings([t.name for t in plotter_themes.THEMES])
+        for n, theme in enumerate(plotter_themes.THEMES):
+            if theme.name == self.settings.diagram_theme:
+                self.diagram_theme_dropdown.set_selected(n)
+        self.diagram_theme_dropdown.connect("notify::selected", self.diagram_theme_changed)
+        self.diagram_theme_box.append(self.diagram_theme_dropdown)
+        curve_settings_list.append(self.diagram_theme_box)
+
         curve_style_box = Box(
             orientation=Orientation.HORIZONTAL,
             spacing=4,
@@ -124,6 +143,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         curve_style_box.append(Label(label=_("Style"), hexpand=True, xalign=0))
         curve_style_box.append(curve_style_buttons_box)
         curve_settings_list.append(curve_style_box)
+
 
         snap_values_box = Box(
             orientation=Orientation.HORIZONTAL,
@@ -189,6 +209,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         display_half_spaces_box.append(display_half_spaces_buttons_box)
         curve_settings_list.append(display_half_spaces_box)
 
+
+
         curve_settings_group.add(curve_settings_list)
 
         self.page.add(curve_settings_group)
@@ -241,6 +263,11 @@ class PreferencesWindow(Adw.PreferencesWindow):
         if widget.get_active():
             self.settings.display_half_spaces = DisplayHalfSpaces.ONLY_RELEVANT
             self.update()
+
+    def diagram_theme_changed(self, *args):
+        selected = self.diagram_theme_dropdown.get_selected()
+        self.settings.diagram_theme = plotter_themes.THEMES[selected].name
+        self.update()
 
     def update(self):
         self.on_update_settings()

--- a/photometric_viewer/gui/pages/content.py
+++ b/photometric_viewer/gui/pages/content.py
@@ -66,4 +66,5 @@ class PhotometryContent(Adw.Bin):
         self.properties.set_photometry(photometry)
 
     def update_settings(self, settings: Settings):
+        self.diagram.update_settings(settings)
         self.geometry.update_settings(settings)

--- a/photometric_viewer/gui/widgets/content/diagram.py
+++ b/photometric_viewer/gui/widgets/content/diagram.py
@@ -2,7 +2,9 @@ import cairo
 from gi.repository import Gtk
 
 from photometric_viewer.model.photometry import Photometry
-from photometric_viewer.utils.plotters import LightDistributionPlotter
+from photometric_viewer.model.settings import Settings
+from photometric_viewer.utils.plotters import LightDistributionPlotter, DiagramStyle, SnapValueAnglesTo, \
+    DisplayHalfSpaces
 
 
 class PhotometricDiagram(Gtk.DrawingArea):
@@ -21,4 +23,10 @@ class PhotometricDiagram(Gtk.DrawingArea):
 
     def set_photometry(self, photometry: Photometry):
         self.photometry = photometry
+        self.queue_draw()
+
+    def update_settings(self, settings: Settings):
+        self.plotter.settings.style = DiagramStyle(settings.diagram_style.value)
+        self.plotter.settings.snap_value_angles_to = SnapValueAnglesTo(settings.snap_value_angles_to.value)
+        self.plotter.settings.display_half_spaces = DisplayHalfSpaces(settings.display_half_spaces.value)
         self.queue_draw()

--- a/photometric_viewer/gui/widgets/content/diagram.py
+++ b/photometric_viewer/gui/widgets/content/diagram.py
@@ -1,15 +1,20 @@
 import cairo
-from gi.repository import Gtk
+from gi.repository import Gtk, Adw
 
 from photometric_viewer.model.photometry import Photometry
 from photometric_viewer.model.settings import Settings
+from photometric_viewer.utils import plotter_themes
 from photometric_viewer.utils.plotters import LightDistributionPlotter, DiagramStyle, SnapValueAnglesTo, \
-    DisplayHalfSpaces
+    DisplayHalfSpaces, LightDistributionPlotterSettings
 
 
 class PhotometricDiagram(Gtk.DrawingArea):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.style_manager: Adw.StyleManager = Adw.StyleManager.get_default()
+        self.style_manager.connect("notify", self.on_style_manager_notify)
+        self.selected_theme = plotter_themes.THEMES[0]
+
         self.set_css_classes(["boxed-list"])
         self.set_draw_func(self.on_draw)
         self.photometry = None
@@ -29,4 +34,23 @@ class PhotometricDiagram(Gtk.DrawingArea):
         self.plotter.settings.style = DiagramStyle(settings.diagram_style.value)
         self.plotter.settings.snap_value_angles_to = SnapValueAnglesTo(settings.snap_value_angles_to.value)
         self.plotter.settings.display_half_spaces = DisplayHalfSpaces(settings.display_half_spaces.value)
+
+        selected_theme = [theme for theme in plotter_themes.THEMES if theme.name == settings.diagram_theme]
+
+        if selected_theme:
+            self.selected_theme = selected_theme[0]
+        else:
+            self.selected_theme = plotter_themes.THEMES[0]
+        self._update_plotter_theme()
+
+        self.queue_draw()
+
+    def _update_plotter_theme(self):
+        if self.style_manager.get_dark():
+            self.plotter.settings.theme = self.selected_theme.plotter_theme_dark
+        else:
+            self.plotter.settings.theme = self.selected_theme.plotter_theme
+
+    def on_style_manager_notify(self, *args):
+        self._update_plotter_theme()
         self.queue_draw()

--- a/photometric_viewer/model/settings.py
+++ b/photometric_viewer/model/settings.py
@@ -25,3 +25,4 @@ class Settings:
     diagram_style: DiagramStyle = DiagramStyle.SIMPLE
     snap_value_angles_to: SnapValueAnglesTo = SnapValueAnglesTo.MAX_VALUE
     display_half_spaces: DisplayHalfSpaces = DisplayHalfSpaces.ONLY_RELEVANT
+    diagram_theme: str | None = None

--- a/photometric_viewer/model/settings.py
+++ b/photometric_viewer/model/settings.py
@@ -1,9 +1,27 @@
 from dataclasses import dataclass
+from enum import Enum
 
 from photometric_viewer.model.units import LengthUnits
+
+class DiagramStyle(Enum):
+    SIMPLE = 1
+    DETAILED = 2
+
+
+class SnapValueAnglesTo(Enum):
+    MAX_VALUE = 1
+    ROUND_NUMBER = 2
+
+
+class DisplayHalfSpaces(Enum):
+    BOTH = 1
+    ONLY_RELEVANT = 2
 
 
 @dataclass
 class Settings:
-    length_units_from_file: bool
-    length_units: LengthUnits | None
+    length_units_from_file: bool = False
+    length_units: LengthUnits | None = LengthUnits.METERS
+    diagram_style: DiagramStyle = DiagramStyle.SIMPLE
+    snap_value_angles_to: SnapValueAnglesTo = SnapValueAnglesTo.MAX_VALUE
+    display_half_spaces: DisplayHalfSpaces = DisplayHalfSpaces.ONLY_RELEVANT

--- a/photometric_viewer/utils/GSettings.py
+++ b/photometric_viewer/utils/GSettings.py
@@ -26,6 +26,7 @@ class GSettings:
         self.settings.set_enum("diagram-style", settings.diagram_style.value)
         self.settings.set_enum("display-half-spaces", settings.display_half_spaces.value)
         self.settings.set_enum("snap-value-angles-to", settings.snap_value_angles_to.value)
+        self.settings.set_string("diagram-theme", settings.diagram_theme)
 
     def load(self):
         if not self.settings:
@@ -36,5 +37,6 @@ class GSettings:
             length_units=LengthUnits(self.settings.get_enum("preferred-length-units")),
             diagram_style=DiagramStyle(self.settings.get_enum("diagram-style")),
             display_half_spaces=DisplayHalfSpaces(self.settings.get_enum("display-half-spaces")),
-            snap_value_angles_to=SnapValueAnglesTo(self.settings.get_enum("snap-value-angles-to"))
+            snap_value_angles_to=SnapValueAnglesTo(self.settings.get_enum("snap-value-angles-to")),
+            diagram_theme=self.settings.get_string("diagram-theme")
         )

--- a/photometric_viewer/utils/GSettings.py
+++ b/photometric_viewer/utils/GSettings.py
@@ -1,6 +1,8 @@
+import signal
+
 from gi.repository import Gio
 
-from photometric_viewer.model.settings import Settings
+from photometric_viewer.model.settings import Settings, DiagramStyle, DisplayHalfSpaces, SnapValueAnglesTo
 from photometric_viewer.model.units import LengthUnits
 
 
@@ -21,12 +23,18 @@ class GSettings:
 
         self.settings.set_boolean("length-units-from-file", settings.length_units_from_file)
         self.settings.set_enum("preferred-length-units", settings.length_units.value)
+        self.settings.set_enum("diagram-style", settings.diagram_style.value)
+        self.settings.set_enum("display-half-spaces", settings.display_half_spaces.value)
+        self.settings.set_enum("snap-value-angles-to", settings.snap_value_angles_to.value)
 
     def load(self):
         if not self.settings:
-            return Settings(length_units_from_file=False, length_units=LengthUnits.METERS)
+            return Settings()
 
         return Settings(
             length_units_from_file=self.settings.get_boolean("length-units-from-file"),
-            length_units=LengthUnits(self.settings.get_enum("preferred-length-units"))
+            length_units=LengthUnits(self.settings.get_enum("preferred-length-units")),
+            diagram_style=DiagramStyle(self.settings.get_enum("diagram-style")),
+            display_half_spaces=DisplayHalfSpaces(self.settings.get_enum("display-half-spaces")),
+            snap_value_angles_to=SnapValueAnglesTo(self.settings.get_enum("snap-value-angles-to"))
         )

--- a/photometric_viewer/utils/gio.py
+++ b/photometric_viewer/utils/gio.py
@@ -3,9 +3,17 @@ import io
 from gi.repository import Gio, GLib
 
 
+def _detect_encoding(contents):
+    if b'\xae' in contents:
+        return "windows-1252"
+
+    return "utf-8"
+
+
 def gio_file_stream(file: Gio.File):
     _, contents, _ = file.load_contents()
-    return io.TextIOWrapper(io.BytesIO(contents), encoding="utf-8")
+    encoding = _detect_encoding(contents)
+    return io.TextIOWrapper(io.BytesIO(contents), encoding=encoding)
 
 
 def write_string(file: Gio.File, data: str):

--- a/photometric_viewer/utils/plotter_themes.py
+++ b/photometric_viewer/utils/plotter_themes.py
@@ -1,0 +1,169 @@
+from dataclasses import dataclass
+
+from photometric_viewer.utils.plotters import LightDistributionPlotterTheme
+
+@dataclass
+class Theme:
+    name: str
+    plotter_theme: LightDistributionPlotterTheme
+    plotter_theme_dark: LightDistributionPlotterTheme
+
+THEMES = [
+    Theme(
+        name="Adwaita",
+        plotter_theme=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[],
+            coordinate_color=(0.5, 0.5, 0.5, 0.3),
+            text_color=(0, 0, 0, 0.8),
+            curve_line_width=2,
+            c0_stroke=(0x35/0xff, 0x84/0xff, 0xe4/0xff, 1),
+            c0_fill=(0xfa/0xff, 0xfa/0xff, 0xfa/0xff, 0.6),
+            c0_dash=[],
+            c180_stroke=(0xf6/0xff, 0xd3/0xff, 0x2d/0xff, 1),
+            c180_fill=(0xfa/0xff, 0xfa/0xff, 0xfa/0xff, 0.6),
+            c180_dash=[],
+        ),
+        plotter_theme_dark=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[],
+            coordinate_color=(0.5, 0.5, 0.5, 0.3),
+            text_color=(1, 1, 1, 1),
+            curve_line_width=2,
+            c0_stroke=(0x35/0xff, 0x84/0xff, 0xe4/0xff, 1),
+            c0_fill=(0x38/0xff, 0x38/0xff, 0x38/0xff, 0.6),
+            c0_dash=[],
+            c180_stroke=(0xf6/0xff, 0xd3/0xff, 0x2d/0xff, 1),
+            c180_fill=(0x38/0xff, 0x38/0xff, 0x38/0xff, 0.6),
+            c180_dash=[],
+        )
+    ),
+    Theme(
+        name="Classic",
+        plotter_theme=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[4],
+            coordinate_color=(0.6, 0.6, 0.6, 1),
+            text_color=(0.6, 0.6, 0.6, 1),
+            curve_line_width=2,
+            c0_stroke=(0.8, 0.8, 0, 0.4),
+            c0_fill=(0.8, 0.8, 0, 0.2),
+            c0_dash=[],
+            c180_stroke=(0.8, 0.8, 0.0, 0.4),
+            c180_fill=(0.8, 0.8, 0, 0.2),
+            c180_dash=[2],
+        ),
+        plotter_theme_dark=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[4],
+            coordinate_color=(0.6, 0.6, 0.6, 1),
+            text_color=(0.6, 0.6, 0.6, 1),
+            curve_line_width=2,
+            c0_stroke=(0.8, 0.8, 0, 0.4),
+            c0_fill=(0.8, 0.8, 0, 0.2),
+            c0_dash=[],
+            c180_stroke=(0.8, 0.8, 0.0, 0.4),
+            c180_fill=(0.8, 0.8, 0, 0.2),
+            c180_dash=[2],
+        )
+    ),
+    Theme(
+        name="Luxor",
+        plotter_theme=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[],
+            coordinate_color=(0.8, 0.8, 0.8, 1),
+            text_color=(0.0, 0.0, 0.0, 1),
+            curve_line_width=1,
+            c0_stroke=(1, 0.0, 0, 0.9),
+            c0_fill=(1, 1, 0.4, 0.5),
+            c0_dash=[],
+            c180_stroke=(0, 0.0, 1, 0.9),
+            c180_fill=(1, 1, 0.4, 0.5),
+            c180_dash=[],
+        ),
+        plotter_theme_dark=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[],
+            coordinate_color=(0.8, 0.8, 0.8, 1),
+            text_color=(1, 1, 1, 1),
+            curve_line_width=1,
+            c0_stroke=(1, 0.2, 0.2, 1),
+            c0_fill=(1, 1, 0.4, 0.2),
+            c0_dash=[],
+            c180_stroke=(0.4, 0.4, 1, 1),
+            c180_fill=(1, 1, 0.4, 0.2),
+            c180_dash=[],
+        )
+    ),
+    Theme(
+        name="High Contrast",
+        plotter_theme=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[1],
+            coordinate_color=(0.5, 0.5, 0.5, 1),
+            text_color=(0.0, 0.0, 0.0, 1),
+            curve_line_width=2,
+            c0_stroke=(0.2, 0.2, 0.2, 1),
+            c0_fill=None,
+            c0_dash=[],
+            c180_stroke=(0.2, 0.2, 0.2, 1),
+            c180_fill=None,
+            c180_dash=[3],
+        ),
+        plotter_theme_dark=LightDistributionPlotterTheme(
+            background_color=None,
+            coordinate_line_width=1,
+            coordinate_line_dash=[1],
+            coordinate_color=(0.9, 0.9, 0.9, 1),
+            text_color=(0.9, 0.9, 0.9, 1),
+            curve_line_width=2,
+            c0_stroke=(0.9, 0.9, 0.9, 1),
+            c0_fill=None,
+            c0_dash=[],
+            c180_stroke=(0.9, 0.9, 0.9, 1),
+            c180_fill=None,
+            c180_dash=[3],
+        ),
+    ),
+
+    Theme(
+        name="Solarized",
+        plotter_theme=LightDistributionPlotterTheme(
+            background_color=(0.93, 0.96, 0.83, 1),
+            coordinate_line_width=1,
+            coordinate_line_dash=[],
+            coordinate_color=(0.5, 0.5, 0.5, 0.3),
+            text_color=(0.4, 0.4, 0.4, 1),
+            curve_line_width=2,
+            c0_stroke=(0.15, 0.55, 0.82, 1),
+            c0_fill=(0.99, 0.96, 0.89, 0.5),
+            c0_dash=[],
+            c180_stroke=(0.71, 0.54, 0.0, 1),
+            c180_fill=(0.99, 0.96, 0.89, 0.5),
+            c180_dash=[],
+        ),
+        plotter_theme_dark=LightDistributionPlotterTheme(
+            background_color=(0.0, 0.17, 0.21, 1),
+            coordinate_line_width=1,
+            coordinate_line_dash=[],
+            coordinate_color=(0.5, 0.5, 0.5, 0.3),
+            text_color=(0.4, 0.4, 0.4, 1),
+            curve_line_width=2,
+            c0_stroke=(0.15, 0.55, 0.82, 1),
+            c0_fill=(0.03, 0.21, 0.26, 0.5),
+            c0_dash=[],
+            c180_stroke=(0.71, 0.54, 0.0, 1),
+            c180_fill=(0.03, 0.21, 0.26, 0.5),
+            c180_dash=[],
+        )
+    )
+
+]

--- a/photometric_viewer/utils/plotters.py
+++ b/photometric_viewer/utils/plotters.py
@@ -97,10 +97,10 @@ class LightDistributionPlotter:
         if type(self.settings.snap_value_angles_to) == int:
             return self.settings.snap_value_angles_to
 
-        round_values = [30, 60, 90, 100,
-                        300, 600, 900, 1000,
-                        3000, 6000, 9000, 10000,
-                        30000, 60000, 90000, 100000]
+        round_values = [30, 48, 60, 90, 100,
+                        300, 480, 600, 900, 1000,
+                        3000, 4800, 6000, 9000, 10000,
+                        30000, 48000, 60000, 90000, 100000]
 
         last_round_value = 0
         for round_value in round_values:

--- a/photometric_viewer/utils/plotters.py
+++ b/photometric_viewer/utils/plotters.py
@@ -1,92 +1,221 @@
 import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Tuple
 
 import cairo
 from photometric_viewer.model.photometry import Photometry
 from photometric_viewer.utils.coordinates import cartesian_to_screen
 
 
-def _get_max_candela(photometry: Photometry):
-    max_candelas = 0
 
-    for c_angle in [0, 90, 180, 270]:
-        values = photometry.get_values_for_c_angle(c_angle)
-        for angle, candelas in values.items():
-            if candelas > max_candelas:
-                max_candelas = candelas
 
-    return max_candelas
+class DiagramStyle(Enum):
+    SIMPLE = 1
+    DETAILED = 2
+
+
+class SnapValueAnglesTo(Enum):
+    MAX_VALUE = 1
+    ROUND_NUMBER = 2
+
+class DisplayHalfSpaces(Enum):
+    BOTH = 1
+    ONLY_RELEVANT = 2
+
+@dataclass
+class LightDistributionPlotterSettings:
+    style: DiagramStyle = DiagramStyle.DETAILED
+    background_color: Tuple[float, float, float, float] | None = None
+    coordinate_line_width = 1
+    coordinate_color = (0.6, 0.6, 0.6, 1)
+    text_color = (0.6, 0.6, 0.6, 1)
+    curve_line_width: float = 2
+    c0_stroke: Tuple[float, float, float, float] = (0.8, 0.8, 0, 0.4)
+    c0_fill: Tuple[float, float, float, float] | None = (0.8, 0.8, 0, 0.2)
+    c0_dash: Tuple[float] = ()
+    c180_stroke: Tuple[float, float, float, float] = (0.8, 0.8, 0.0, 0.4)
+    c180_fill: Tuple[float, float, float, float] | None = (0.8, 0.8, 0, 0.2)
+    c180_dash: Tuple[float] = (2,)
+    show_legend: bool = True
+    snap_value_angles_to: SnapValueAnglesTo | int = SnapValueAnglesTo.ROUND_NUMBER
+    display_half_spaces: DisplayHalfSpaces = DisplayHalfSpaces.ONLY_RELEVANT
+
 
 
 class LightDistributionPlotter:
-    def __init__(self):
+    def __init__(self, settings: LightDistributionPlotterSettings = LightDistributionPlotterSettings()):
         self.size = 300
+        self.center = 150
+        self.settings = settings
 
     def draw(self, context: cairo.Context, photometry: Photometry):
+        self.center = self._get_center(photometry)
+        self._draw_background(context)
         self._draw_coordinate_system(context, photometry)
         self._draw_curve(context, photometry)
         self._draw_legend(context)
 
+    def _get_center(self, photometry: Photometry):
+        if self.settings.display_half_spaces == DisplayHalfSpaces.BOTH:
+            return self.size / 2, self.size / 2
+
+        max_lower_half = 0
+        max_upper_half = 0
+        max_other = 0
+        for c_angle in [0, 90, 180, 270]:
+            values = photometry.get_values_for_c_angle(c_angle)
+            for angle, candelas in values.items():
+                if angle < 45 and candelas > max_lower_half:
+                    max_lower_half = candelas
+                if angle >= 135 and candelas > max_upper_half:
+                    max_upper_half = candelas
+                if angle >= 45 and angle < 135 and candelas > max_other:
+                    max_other = candelas
+
+        if max_other > max_upper_half and max_other > max_lower_half:
+            return self.size / 2, self.size / 2
+        elif max_upper_half < 0.25 * max_lower_half:
+            return self.size / 2, self.size * 0.1
+        elif max_upper_half > 0.75 * max_lower_half:
+            return self.size / 2, self.size * 0.9
+        else:
+            return self.size / 2, self.size * 0.5
+
+    def _get_max_candela(self, photometry: Photometry):
+        max_candelas = 0
+
+        for c_angle in [0, 90, 180, 270]:
+            values = photometry.get_values_for_c_angle(c_angle)
+            for angle, candelas in values.items():
+                if candelas > max_candelas:
+                    max_candelas = candelas
+
+        if self.settings.snap_value_angles_to == SnapValueAnglesTo.MAX_VALUE:
+            return max_candelas
+
+        if type(self.settings.snap_value_angles_to) == int:
+            return self.settings.snap_value_angles_to
+
+        if self.settings.style == DiagramStyle.SIMPLE:
+            round_values = [60, 120, 240, 360, 600, 1200, 2400, 3600, 6000, 2400, 3600, 12000, 24000, 36000]
+        else:
+            round_values = [50, 80, 100, 200, 400,
+                            500, 800, 1000, 2000, 4000,
+                            5000, 8000, 10000, 20000, 40000]
+
+        last_round_value = 0
+        for round_value in round_values:
+            if max_candelas > last_round_value:
+                last_round_value = round_value
+
+        return last_round_value
+
+    def _draw_background(self, context: cairo.Context):
+        if self.settings.background_color is None:
+            return
+        context.set_source_rgba(
+            self.settings.background_color[0],
+            self.settings.background_color[1],
+            self.settings.background_color[2],
+            self.settings.background_color[3]
+        )
+        context.rectangle(0, 0, self.size, self.size)
+        context.fill()
+
     def _draw_coordinate_system(self, context: cairo.Context, photometry: Photometry):
-        center = self.size / 2, self.size / 2
-
-        context.set_line_width(1)
+        context.set_line_width(self.settings.coordinate_line_width)
         context.set_dash([4])
-        context.set_source_rgb(0.6, 0.6, 0.6)
+        r, g, b, a = self.settings.coordinate_color
+        context.set_source_rgba(r, g, b, a)
 
-        radii = [
-            int((self.size - 50) * 1 / 6),
-            int((self.size - 50) * 2 / 6),
-            int((self.size - 50) * 3 / 6),
-        ]
+        if self.center[1] == self.size / 2:
+            ratio = 0.4
+        else:
+            ratio = 0.8
+
+        if self.settings.style == DiagramStyle.SIMPLE:
+            radii = [
+                int(self.size * 0.3333 * ratio),
+                int(self.size * 0.6666 * ratio),
+                int(self.size * 1 * ratio),
+                int(self.size * 1.3333 * ratio),
+                int(self.size * 1.6666 * ratio),
+            ]
+        else:
+            radii = [
+                int(self.size * 0.25 * ratio),
+                int(self.size * 0.5 * ratio),
+                int(self.size * 0.75 * ratio),
+                int(self.size * 1 * ratio),
+                int(self.size * 1.25 * ratio),
+                int(self.size * 1.5 * ratio),
+            ]
 
         # Draw circles
         for radius in radii:
-            context.arc(center[0], center[1], radius, 0, 2 * math.pi)
+            context.arc(self.center[0], self.center[1], radius, 0, 2 * math.pi)
             context.stroke()
 
         # Draw spokes
-        for angle in [math.pi * x / 4 for x in range(8)]:
-            context.move_to(self.size / 2, self.size / 2)
-            point = cartesian_to_screen(center, (math.cos(angle) * self.size, math.sin(angle) * self.size))
+        n_spokes = 8 if self.settings.style == DiagramStyle.SIMPLE else 16
+        for angle in [math.pi * x / (n_spokes / 2) for x in range(n_spokes)]:
+            context.move_to(self.center[0], self.center[1])
+            point = cartesian_to_screen(self.center, (math.cos(angle) * self.size, math.sin(angle) * self.size))
             point_clipped_to_canvas = (
-                min(self.size, max(0, point[0])),
-                min(self.size, max(1, point[1]))
+                point[0], point[1]
             )
             context.line_to(point_clipped_to_canvas[0], point_clipped_to_canvas[1])
             context.stroke()
 
-        self.draw_values(center, context, photometry, radii)
+        self.draw_values(self.center, context, photometry, radii)
 
-    @staticmethod
-    def draw_values(center, context, photometry, radii):
-        max_candelas = _get_max_candela(photometry)
+    def draw_values(self, center, context, photometry, radii):
+        r, g, b, a = self.settings.text_color
+        context.set_source_rgba(r, g, b, a)
+
+        max_candelas = self._get_max_candela(photometry)
         for n, radius in enumerate(radii):
             unit = "cd" if photometry.is_absolute else "cd/klm"
-            value = max_candelas * (n + 1) / 3
+            value = max_candelas * (n + 1) / (len(radii) - 2)
 
             text = f"{value:.0f} {unit}"
             extents = context.text_extents(text)
-            first_value_point = cartesian_to_screen(center, (-(extents.width / 2), -radius - 15))
+            if center[1] > 0.5 * self.size:
+                first_value_point = cartesian_to_screen(center, (-(extents.width / 2), radius - 15))
+            else:
+                first_value_point = cartesian_to_screen(center, (-(extents.width / 2), -radius - 15))
+
             context.move_to(first_value_point[0], first_value_point[1])
             context.show_text(text)
 
     def _draw_curve(self, context: cairo.Context, photometry: Photometry):
-        context.set_line_width(2)
-        context.set_source_rgba(0.8, 0.8, 0, 0.4)
+        context.set_line_width(self.settings.curve_line_width)
+        max_candelas = self._get_max_candela(photometry)
 
-        max_candelas = _get_max_candela(photometry)
+        context.set_dash(self.settings.c0_dash)
+        self._draw_halfcurve(context, photometry, max_candelas, 0, self.settings.c0_stroke, self.settings.c0_fill)
+        self._draw_halfcurve(context, photometry, max_candelas, 180, self.settings.c0_stroke, self.settings.c0_fill)
 
-        context.set_dash([])
-        self._draw_halfcurve(context, photometry, max_candelas, 0)
-        self._draw_halfcurve(context, photometry, max_candelas, 180)
+        context.set_dash(self.settings.c180_dash)
+        self._draw_halfcurve(context, photometry, max_candelas, 90, self.settings.c180_stroke, self.settings.c180_fill)
+        self._draw_halfcurve(context, photometry, max_candelas, 270, self.settings.c180_stroke, self.settings.c180_fill)
 
-        context.set_dash([2])
-        self._draw_halfcurve(context, photometry, max_candelas, 90)
-        self._draw_halfcurve(context, photometry, max_candelas, 270)
+    def _draw_halfcurve(
+            self,
+            context: cairo.Context,
+            photometry: Photometry,
+            max_candelas,
+            c_angle,
+            stroke,
+            fill
+    ):
 
-    def _draw_halfcurve(self, context: cairo.Context, photometry: Photometry, max_candelas, c_angle):
-        center = self.size / 2, self.size / 2
-        max_candelas_scale = int((self.size - 50) * 3 / 6)
+        if self.center[1] == self.size / 2:
+            max_candelas_scale = int(self.size * 0.4)
+        else:
+            max_candelas_scale = int(self.size * 0.8)
+
         angle_modifier = 1 if c_angle < 180 else -1
 
         context.new_path()
@@ -98,46 +227,55 @@ class LightDistributionPlotter:
                 math.cos(angle_modifier * angle - math.pi / 2) * distance,
                 math.sin(angle_modifier * angle - math.pi / 2) * distance
             )
-            point = cartesian_to_screen(center, cartesian_point)
+            point = cartesian_to_screen(self.center, cartesian_point)
             if is_first_point:
                 context.move_to(point[0], point[1])
                 is_first_point = False
             else:
                 context.line_to(int(point[0]), int(point[1]))
 
-        context.set_source_rgba(0.8, 0.8, 0, 0.4)
+        r, g, b, a = stroke
+        context.set_source_rgba(r, g, b, a)
         context.stroke_preserve()
 
-        context.set_source_rgba(0.8, 0.8, 0, 0.2)
-        context.fill()
+        if fill is not None:
+            r, g, b, a = fill
+            context.set_source_rgba(r, g, b, a)
+            context.fill()
 
     def _draw_legend(self, context: cairo.Context):
-        context.set_line_width(2)
+        if not self.settings.show_legend:
+            return
+
+        context.set_line_width(self.settings.curve_line_width)
 
         context.new_path()
-        context.set_dash([])
-
-        context.set_source_rgba(0.8, 0.8, 0, 0.6)
+        context.set_dash(self.settings.c0_dash)
+        r, g, b, a = self.settings.c0_stroke
+        context.set_source_rgba(r, g, b, a)
         context.move_to(self.size - 100, self.size - 20)
         context.line_to(self.size - 100 + 15, self.size - 20)
         context.stroke()
 
         context.new_path()
         context.move_to(self.size - 100 + 18, self.size - 17)
-        context.set_source_rgb(0.6, 0.6, 0.6)
+        r, g, b, a = self.settings.text_color
+        context.set_source_rgba(r, g, b, a)
         context.show_text("C0-C180")
         context.stroke()
 
         context.new_path()
-        context.set_dash([2])
+        context.set_dash(self.settings.c180_dash)
 
-        context.set_source_rgba(0.8, 0.8, 0, 0.6)
+        r, g, b, a = self.settings.c180_stroke
+        context.set_source_rgba(r, g, b, a)
         context.move_to(self.size - 100, self.size - 8)
         context.line_to(self.size - 100 + 15, self.size - 8)
         context.stroke()
 
         context.new_path()
         context.move_to(self.size - 100 + 18, self.size - 5)
-        context.set_source_rgb(0.6, 0.6, 0.6)
+        r, g, b, a = self.settings.text_color
+        context.set_source_rgba(r, g, b, a)
         context.show_text("C90-C270")
         context.stroke()

--- a/photometric_viewer/utils/plotters.py
+++ b/photometric_viewer/utils/plotters.py
@@ -97,12 +97,10 @@ class LightDistributionPlotter:
         if type(self.settings.snap_value_angles_to) == int:
             return self.settings.snap_value_angles_to
 
-        if self.settings.style == DiagramStyle.SIMPLE:
-            round_values = [60, 120, 240, 360, 600, 1200, 2400, 3600, 6000, 2400, 3600, 12000, 24000, 36000]
-        else:
-            round_values = [50, 80, 100, 200, 400,
-                            500, 800, 1000, 2000, 4000,
-                            5000, 8000, 10000, 20000, 40000]
+        round_values = [30, 60, 90, 100,
+                        300, 600, 900, 1000,
+                        3000, 6000, 9000, 10000,
+                        30000, 60000, 90000, 100000]
 
         last_round_value = 0
         for round_value in round_values:


### PR DESCRIPTION
Allows modifying appearance of light distribution curves:

- Theme
- Style (Simple / Detailed)
- Snap guides to maximal value or next round number
- Display both or only relevant half spaces

Close #17 