### PR TITLE
Bugfix: Application crashes when opening files from start page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+.flatpak-builder
+build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+build:
+	python3 setup.py build
+
+run:
+	python3 run.py
+
+flatpak-build: flatpak.yaml
+	flatpak-builder --force-clean build/flatpak flatpak.yaml
+
+flatpak-install: flatpak-build
+	flatpak-builder --user --install --force-clean build/flatpak flatpak.yaml
+
+flatpak-run: flatpak-install
+	flatpak run io.github.dlippok.photometric-viewer
+
+flatpack-uninstall:
+	flatpak uninstall -y io.github.dlippok.photometric-viewer
+
+flatpak-clean:
+	rm -rf build/flatpak
+
+
+clean: flatpak-clean
+	rm -rf build

--- a/flatpak.yaml
+++ b/flatpak.yaml
@@ -1,0 +1,19 @@
+app-id: io.github.dlippok.photometric-viewer
+runtime: org.gnome.Platform
+runtime-version: "44"
+sdk: org.gnome.Sdk
+command: photometric-viewer
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+
+modules:
+  - name: photometric-viewer
+    buildsystem: simple
+    build-commands:
+      - pip3 install . --prefix ${FLATPAK_DEST}
+    sources:
+      - type: dir
+        path: .

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -59,8 +59,12 @@ class MainWindow(Adw.Window):
         self.ldc_export_page = LdcExportPage(on_exported=self.on_export_ldc_response, transient_for=self)
         self.view_stack.add_titled(self.ldc_export_page, "ldc_export", _("LDC Export"))
 
+        empty_page = EmptyPage()
+        self.view_stack.add_titled(empty_page, "empty", _("Empty"))
+
+
         self.content_bin = Adw.Bin()
-        self.content_bin.set_child(EmptyPage())
+        self.content_bin.set_child(self.view_stack)
         self.content_bin.set_vexpand(True)
 
         self.banner = Adw.Banner()
@@ -117,6 +121,8 @@ class MainWindow(Adw.Window):
 
         self.drop_target.connect("drop", self.on_drop)
         self.add_controller(self.drop_target)
+
+        self.open_page(empty_page)
 
         if self.gsettings.settings is None:
             self.show_banner(_("Settings schema could not be loaded. Selected settings will be lost on restart"))


### PR DESCRIPTION
When the application is running in Flatpak environment and the user used the button on the start page the application crashes. This PR fixes the crash.

See: #108 