### PR TITLE
Rebranding to Photometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Photometric Viewer
+# Photometry
 
 Application for viewing IES and EULUMDAT photometric files under Linux (Gnome/GTK).
 

--- a/data/desktop/io.github.dlippok.photometric-viewer.desktop
+++ b/data/desktop/io.github.dlippok.photometric-viewer.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
-Name=Photometric Viewer
-Name[de]=Photometriebetrachter
+Name=Photometry
+Name[de]=Photometrie
+Name[pl]=Fotometria
 Comment=Browse content of photometric files
 Comment[de]=Öffne Photometriedateien
 Comment[pl]=Przeglądaj zawartość plików fotometrycznych

--- a/data/icons/io.github.dlippok.photometric-viewer-symbolic.svg
+++ b/data/icons/io.github.dlippok.photometric-viewer-symbolic.svg
@@ -2,11 +2,13 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="128"
-   height="128"
-   viewBox="0 0 33.866666 33.866668"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
    version="1.1"
    id="svg5"
+   sodipodi:docname="lightbulb-symbolic.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -20,18 +22,37 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:document-units="mm"
-     showgrid="false"
+     showgrid="true"
      units="px"
      showguides="false"
-     inkscape:zoom="1.726283"
-     inkscape:cx="76.464869"
-     inkscape:cy="17.668019"
+     inkscape:zoom="33.61"
+     inkscape:cx="4.2844392"
+     inkscape:cy="8.2267182"
      inkscape:window-width="1920"
-     inkscape:window-height="1016"
+     inkscape:window-height="1011"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       id="grid1"
+       units="mm"
+       originx="0"
+       originy="0"
+       spacingx="0.99999999"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="5"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
   <defs
      id="defs2">
     <linearGradient
@@ -55,10 +76,34 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1">
+    <rect
+       style="display:inline;fill:#77767b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.222121;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+       id="rect22-6"
+       width="0.52916664"
+       height="0.26458332"
+       x="1.8549607"
+       y="3.6737285"
+       ry="0" />
     <path
-       id="path19122"
-       style="opacity:1;fill:none;fill-opacity:0.925797;fill-rule:evenodd;stroke:#5d656b;stroke-width:2.11666667;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 27.075842,14.579359 c 0,2.440334 -2.576271,5.994761 -4.267166,7.648472 -1.851333,1.810626 -0.09234,6.270886 -5.779826,6.315716 -5.639572,0.04449 -4.801083,-5.423792 -6.51304,-6.627834 -2.4064825,-1.692512 -3.7249854,-4.349191 -3.7249854,-7.336354 0,-5.1122177 4.5409534,-9.256486 10.1425084,-9.256486 5.601552,0 10.142509,4.1442683 10.142509,9.256486 z"
-       sodipodi:nodetypes="sssssss" />
+       id="path54741-7"
+       style="display:inline;mix-blend-mode:normal;fill:#77767b;fill-rule:evenodd;stroke:none;stroke-width:0.194562;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="M 3.1417119,1.7533732 C 2.7249578,2.5041102 2.7056426,2.598559 2.6047302,2.6425204 2.5038179,2.6864817 1.7032923,2.680865 1.6236259,2.6398261 1.54396,2.5987867 1.5064706,2.5141851 1.071571,1.7520374 0.63667228,0.98988772 1.1253298,0.091255 2.1115509,0.09017232 3.0977751,0.08903218 3.5584707,1.0026929 3.1417119,1.7534301 Z"
+       sodipodi:nodetypes="zzzzzzz" />
+    <rect
+       style="display:inline;fill:#77767b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.263953;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;enable-background:new"
+       id="rect1"
+       width="1.0583333"
+       height="0.264357"
+       x="1.5744157"
+       y="2.9149387"
+       ry="0" />
+    <rect
+       style="display:inline;fill:#77767b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.264066;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;enable-background:new"
+       id="rect2"
+       width="1.0583333"
+       height="0.26458332"
+       x="1.5848401"
+       y="3.4255688"
+       ry="0" />
   </g>
 </svg>

--- a/data/icons/io.github.dlippok.photometric-viewer.svg
+++ b/data/icons/io.github.dlippok.photometric-viewer.svg
@@ -7,7 +7,8 @@
    viewBox="0 0 33.866666 33.866668"
    version="1.1"
    id="svg5"
-   sodipodi:docname="photometric-viewer.svg"
+   sodipodi:docname="lightbulb.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -21,32 +22,106 @@
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
-     inkscape:document-units="mm"
+     inkscape:document-units="px"
      showgrid="false"
      units="px"
      showguides="false"
-     inkscape:zoom="3.4864882"
-     inkscape:cx="-11.616273"
-     inkscape:cy="64.391441"
+     inkscape:zoom="4.9306388"
+     inkscape:cx="83.356339"
+     inkscape:cy="53.644165"
      inkscape:window-width="1920"
-     inkscape:window-height="1018"
+     inkscape:window-height="1011"
      inkscape:window-x="0"
-     inkscape:window-y="25"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:lockguides="false">
+    <sodipodi:guide
+       position="-19.6018,3.1809222"
+       orientation="0,-1"
+       id="guide54"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-0.34942665,31.750876"
+       orientation="0,-1"
+       id="guide55"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="7.6198711,29.895749"
+       orientation="1,0"
+       id="guide56"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="26.549231,35.499766"
+       orientation="1,0"
+       id="guide57"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="16.935817,36.05201"
+       orientation="1,0"
+       id="guide58"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="2.1248697,17.133318"
+       orientation="0,-1"
+       id="guide59"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-1.5561708,25.871169"
+       orientation="0,-1"
+       id="guide60"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1.0195602,26.40778"
+       orientation="0,-1"
+       id="guide61"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="1.8244762,14.119395"
+       orientation="0,-1"
+       id="guide62"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="26.079277,10.899731"
+       orientation="0,-1"
+       id="guide63"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="4.0220748,18.043977"
+       orientation="0,-1"
+       id="guide64"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="2.6940312,11.669367"
+       orientation="0,-1"
+       id="guide65"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.957224,6.584857"
+       orientation="0,-1"
+       id="guide66"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="15.13242,13.032759"
+       orientation="0,-1"
+       id="guide67"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
   <defs
      id="defs2">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient71713">
+       id="linearGradient19"
+       inkscape:collect="always">
       <stop
-         style="stop-color:#cacaca;stop-opacity:1"
+         style="stop-color:#ffffd7;stop-opacity:1;"
          offset="0"
-         id="stop71709" />
+         id="stop19" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         style="stop-color:#f8e45c;stop-opacity:1"
          offset="1"
-         id="stop71711" />
+         id="stop20" />
     </linearGradient>
     <linearGradient
        id="linearGradient13462"
@@ -64,68 +139,60 @@
          offset="0"
          id="stop12622" />
     </linearGradient>
-    <linearGradient
+    <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient71713"
-       id="linearGradient71715"
-       x1="14.853817"
-       y1="31.187536"
-       x2="14.853817"
-       y2="30.242035"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.30816263,0.02857396)" />
-    <filter
-       inkscape:collect="always"
-       style="color-interpolation-filters:sRGB"
-       id="filter73571"
-       x="-0.014340805"
-       y="-0.012527632"
-       width="1.0286816"
-       height="1.0250553">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.068969851"
-         id="feGaussianBlur73573" />
-    </filter>
+       xlink:href="#linearGradient19"
+       id="radialGradient20"
+       cx="17.224766"
+       cy="8.003231"
+       fx="17.224766"
+       fy="8.003231"
+       r="10.150891"
+       gradientTransform="matrix(0.79964734,-0.00176658,0.00129621,0.58009275,3.3602195,1.7332421)"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1">
     <rect
-       style="opacity:1;fill:url(#linearGradient71715);fill-opacity:1;stroke:#287dff;stroke-width:0.465281;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect45656"
-       width="22.364395"
-       height="23.478767"
-       x="5.7511358"
-       y="7.7910037"
-       ry="2.4993732" />
-    <rect
-       style="opacity:1;fill:#4c92ff;fill-opacity:1;stroke:none;stroke-width:0.808109;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect394"
-       width="22.715233"
-       height="22.937033"
-       x="5.5910082"
-       y="6.0361433"
-       ry="2.4417043" />
+       style="fill:#3d3846;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.09149;stroke-linecap:round;stroke-linejoin:round"
+       id="rect22"
+       width="4.5346918"
+       height="2.737426"
+       x="14.700356"
+       y="29.759974"
+       ry="1.2033846" />
     <path
        id="path54741"
-       style="opacity:1;mix-blend-mode:normal;fill:#f3f3f3;fill-opacity:0.76066226;fill-rule:evenodd;stroke:none;stroke-width:0.558852;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.367897;filter:url(#filter73571)"
-       d="m 22.400551,7.5446954 c 0,1.388581 -1.46593,3.4110946 -2.428071,4.3520756 -1.05343,1.03027 -0.05254,3.568212 -3.288791,3.59372 -3.208985,0.02532 -2.731875,-3.086203 -3.706,-3.771319 -1.369318,-0.963059 -2.119562,-2.4747433 -2.119562,-4.1744766 0,-2.9089148 2.583859,-5.2670544 5.771212,-5.2670544 3.187351,0 5.771212,2.3581396 5.771212,5.2670544 z"
-       sodipodi:nodetypes="sssssss"
-       transform="matrix(1.337047,0,0,1.4680538,-5.1706082,-2.485398)" />
+       style="display:inline;mix-blend-mode:normal;fill:url(#radialGradient20);fill-rule:evenodd;stroke:none;stroke-width:1.04042;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 25.293386,16.342819 c -3.377679,6.642096 -3.534219,7.869208 -4.352076,7.866703 -0.817858,-0.0025 -7.272415,-0.02228 -7.951534,-0.02436 -0.679118,-0.0021 -0.949503,-1.11158 -4.4742202,-7.854657 C 4.9908381,9.5874272 8.9512542,1.6368126 16.944265,1.6272451 c 7.993012,-0.00957 11.726799,8.0734803 8.349121,14.7155739 z"
+       sodipodi:nodetypes="zzzzzz" />
     <path
-       style="fill:none;fill-opacity:0.0358398;fill-rule:evenodd;stroke:#a6c9ff;stroke-width:2.11667;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path64245"
-       sodipodi:type="arc"
-       sodipodi:cx="16.791203"
-       sodipodi:cy="22.300795"
-       sodipodi:rx="8.2625914"
-       sodipodi:ry="4.1312962"
-       sodipodi:start="5.4377191"
-       sodipodi:end="4.0513979"
-       sodipodi:open="true"
-       sodipodi:arc-type="arc"
-       d="m 22.272461,19.209426 a 8.2625914,4.1312962 0 0 1 2.195743,4.618953 8.2625914,4.1312962 0 0 1 -7.942759,2.601574 8.2625914,4.1312962 0 0 1 -7.5917913,-2.851529 8.2625914,4.1312962 0 0 1 2.7851483,-4.538809" />
+       id="rect13-3"
+       style="display:inline;fill:#3584e4;fill-rule:evenodd;stroke:none;stroke-width:1.3365;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 21.925367,23.378228 c -0.0025,1.414469 0,5.471248 0,5.471248 0,3.168494 -9.558074,4.052586 -9.967072,0 0,0 0.01887,-4.020359 0,-5.471248 -0.01891,-1.450889 9.969667,-1.465597 9.967072,0 z"
+       sodipodi:nodetypes="ssszs" />
+    <rect
+       style="fill:#62a0ea;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8.24926;stroke-linecap:round;stroke-linejoin:round"
+       id="rect40"
+       width="10.017923"
+       height="1.2622737"
+       x="11.913101"
+       y="24.197496"
+       ry="0" />
+    <rect
+       style="fill:#62a0ea;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:8.24926;stroke-linecap:round;stroke-linejoin:round"
+       id="rect48"
+       width="10.017923"
+       height="1.2622737"
+       x="11.913101"
+       y="27.487713"
+       ry="0" />
+    <path
+       id="path20"
+       style="display:inline;fill:#1c71d8;fill-opacity:0.524579;fill-rule:evenodd;stroke:none;stroke-width:1.2818;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 20.338379,22.548674 c 0.14929,-0.01529 1.561753,0.334173 1.575484,0.799745 0.05593,1.896527 -0.0356,5.774426 -0.0356,5.774426 -0.507654,2.838203 -9.21336,3.612905 -9.89594,-0.0093 0,0 1.60939,1.925019 5.093754,-0.741763 3.484366,-2.66678 0.471807,-5.537297 2.651687,-5.760553 z"
+       sodipodi:nodetypes="sssszss" />
   </g>
 </svg>

--- a/data/io.github.dlippok.photometric-viewer.metainfo.xml
+++ b/data/io.github.dlippok.photometric-viewer.metainfo.xml
@@ -2,14 +2,14 @@
 <component type="desktop">
     <id>io.github.dlippok.photometric-viewer</id>
     <launchable type="desktop-id">io.github.dlippok.photometric-viewer.desktop</launchable>
-    <name>Photometric Viewer</name>
-    <name xml:lang="de">Photometriebetrachter</name>
+    <name>Photometry</name>
+    <name xml:lang="de">Photometrie</name>
     <summary>Browse content of IES and LDT photometric files</summary>
     <summary xml:lang="de">Öffne IES- und LDT-Photometriedateien</summary>
     <summary xml:lang="pl">Przeglądaj zawartość plików fotometrzcznych IES i LDT</summary>
     <description>
         <p>
-            Photometric Viewer allow viewing light distribution curves and metadata of IESNA and EULUMDAT photometric
+            Photometry allows viewing light distribution curves and metadata of IESNA and EULUMDAT photometric
             files which describe the light distribution of light sources like lamps and luminaires and
             are used mostly for data transfer in the lighting industry and in 3D graphics.
         </p>
@@ -24,10 +24,10 @@
             transferu danych w przemyśle oświetleniowym i grafice 3D.
         </p>
         <p>
-            Photometric Viewer displays following information of the opened photometric file:
+            Photometry following information of the opened photometric file:
         </p>
         <p xml:lang="de">
-            Photometriebetrachter zeigt folgende Informationen über die Photometiredatei an:
+            Photometrie zeigt folgende Informationen über die Photometiredatei an:
         </p>
         <p xml:lang="pl">
             Aplikacja pozwala zobaczyć następujące informacje zawarte w plikach fotometrycznych:

--- a/data/translations/de/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
+++ b/data/translations/de/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
@@ -82,17 +82,6 @@ msgstr "Alle Photometriedateien"
 msgid "All Files"
 msgstr "Alle Dateien"
 
-#: photometric_viewer/gui/dialogs/about.py:7
-#: photometric_viewer/gui/pages/empty.py:14 photometric_viewer/gui/window.py:34
-#: photometric_viewer/gui/window.py:235 photometric_viewer/gui/window.py:272
-#: photometric_viewer/gui/window.py:33 photometric_viewer/gui/window.py:78
-#: photometric_viewer/gui/window.py:218 photometric_viewer/gui/window.py:80
-#: photometric_viewer/gui/window.py:233 photometric_viewer/gui/window.py:74
-#: photometric_viewer/gui/window.py:32 photometric_viewer/gui/window.py:73
-#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:71
-msgid "Photometric Viewer"
-msgstr "Photometriebetrachter"
-
 #: photometric_viewer/gui/dialogs/preferences.py:13
 #: photometric_viewer/gui/dialogs/preferences.py:15
 #: photometric_viewer/gui/dialogs/preferences.py:12
@@ -973,7 +962,7 @@ msgid "Preferences"
 msgstr "Einstellungen"
 
 #: photometric_viewer/gui/widgets/app_menu.py
-msgid "About Photometric Viewer"
+msgid "About Photometry"
 msgstr "Über Photometriebetrachter"
 
 #: photometric_viewer/gui/widgets/app_menu.py

--- a/data/translations/io.github.dlippok.photometric-viewer.pot
+++ b/data/translations/io.github.dlippok.photometric-viewer.pot
@@ -81,17 +81,6 @@ msgstr ""
 msgid "All Files"
 msgstr ""
 
-#: photometric_viewer/gui/dialogs/about.py:7
-#: photometric_viewer/gui/pages/empty.py:14 photometric_viewer/gui/window.py:34
-#: photometric_viewer/gui/window.py:235 photometric_viewer/gui/window.py:272
-#: photometric_viewer/gui/window.py:33 photometric_viewer/gui/window.py:78
-#: photometric_viewer/gui/window.py:218 photometric_viewer/gui/window.py:80
-#: photometric_viewer/gui/window.py:233 photometric_viewer/gui/window.py:74
-#: photometric_viewer/gui/window.py:32 photometric_viewer/gui/window.py:73
-#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:71
-msgid "Photometric Viewer"
-msgstr ""
-
 #: photometric_viewer/gui/dialogs/preferences.py:13
 #: photometric_viewer/gui/dialogs/preferences.py:15
 #: photometric_viewer/gui/dialogs/preferences.py:12
@@ -947,7 +936,7 @@ msgid "Preferences"
 msgstr ""
 
 #: photometric_viewer/gui/widgets/app_menu.py
-msgid "About Photometric Viewer"
+msgid "About Photometry"
 msgstr ""
 
 #: photometric_viewer/gui/widgets/app_menu.py

--- a/data/translations/pl/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
+++ b/data/translations/pl/LC_MESSAGES/io.github.dlippok.photometric-viewer.po
@@ -82,17 +82,6 @@ msgstr "Wszystkie pliki fotometryczne"
 msgid "All Files"
 msgstr "Wszystkie pliki"
 
-#: photometric_viewer/gui/dialogs/about.py:7
-#: photometric_viewer/gui/pages/empty.py:14 photometric_viewer/gui/window.py:34
-#: photometric_viewer/gui/window.py:235 photometric_viewer/gui/window.py:272
-#: photometric_viewer/gui/window.py:33 photometric_viewer/gui/window.py:78
-#: photometric_viewer/gui/window.py:218 photometric_viewer/gui/window.py:80
-#: photometric_viewer/gui/window.py:233 photometric_viewer/gui/window.py:74
-#: photometric_viewer/gui/window.py:32 photometric_viewer/gui/window.py:73
-#: photometric_viewer/gui/window.py:30 photometric_viewer/gui/window.py:71
-msgid "Photometric Viewer"
-msgstr "Photometric Viewer"
-
 #: photometric_viewer/gui/dialogs/preferences.py:13
 #: photometric_viewer/gui/dialogs/preferences.py:15
 #: photometric_viewer/gui/dialogs/preferences.py:12
@@ -970,7 +959,7 @@ msgid "Preferences"
 msgstr "Ustawienia"
 
 #: photometric_viewer/gui/widgets/app_menu.py
-msgid "About Photometric Viewer"
+msgid "About Photometry"
 msgstr "O programie"
 
 #: photometric_viewer/gui/widgets/app_menu.py

--- a/photometric_viewer/formats/ldt.py
+++ b/photometric_viewer/formats/ldt.py
@@ -268,7 +268,7 @@ def export_to_file(f: IO, luminaire: Luminaire):
     _write_line(f, luminaire.metadata.luminaire, max_len=78)
     _write_line(f, luminaire.metadata.catalog_number, max_len=78)
     _write_line(f, luminaire.metadata.filename)
-    date_and_user = luminaire.metadata.date_and_user or datetime.today().strftime("%Y-%m-%d") + " exported by Photometric Viewer"
+    date_and_user = luminaire.metadata.date_and_user or datetime.today().strftime("%Y-%m-%d") + " exported by Photometry"
     _write_line(f, date_and_user, max_len=78)
 
     if luminaire.geometry:

--- a/photometric_viewer/gui/dialogs/about.py
+++ b/photometric_viewer/gui/dialogs/about.py
@@ -4,7 +4,7 @@ from gi.repository import Adw, Gtk
 class AboutWindow:
     def __init__(self):
         self._about_window = Adw.AboutWindow(
-            application_name=_("Photometric Viewer"),
+            application_name=_("Photometry"),
             application_icon="io.github.dlippok.photometric-viewer",
             developer_name="Damian Lippok",
             version="1.6.1",

--- a/photometric_viewer/gui/pages/empty.py
+++ b/photometric_viewer/gui/pages/empty.py
@@ -11,7 +11,7 @@ class EmptyPage(Adw.Bin):
         app_icon_image.set_pixel_size(200)
         box.append(app_icon_image)
 
-        box.append(Label(label=_("Photometric Viewer"), css_classes=["title-1"]))
+        box.append(Label(label=_("Photometry"), css_classes=["title-1"]))
         box.append(Label(label=_("Open photometric file to display it here")))
 
         open_button = Gtk.Button(

--- a/photometric_viewer/gui/widgets/app_menu.py
+++ b/photometric_viewer/gui/widgets/app_menu.py
@@ -14,7 +14,7 @@ class ApplicationMenuButton(Gtk.MenuButton):
                     <attribute name='action'>app.show_preferences</attribute>
                 </item>
                 <item>
-                    <attribute name='label' translatable='yes'>About Photometric Viewer</attribute>
+                    <attribute name='label' translatable='yes'>About Photometry</attribute>
                     <attribute name='action'>app.show_about_window</attribute>
                 </item>
             </section>

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -31,7 +31,7 @@ from photometric_viewer.utils.gi.gio import gio_file_stream, write_string
 class MainWindow(Adw.Window):
     def __init__(self, **kwargs):
         super().__init__(
-            title=_('Photometric Viewer'),
+            title=_('Photometry'),
             **kwargs
         )
 
@@ -238,7 +238,7 @@ class MainWindow(Adw.Window):
         file: Gio.File = dialog.get_file()
 
         export_keywords = {
-            "_EXPORT_TOOL": _("Photometric Viewer"),
+            "_EXPORT_TOOL": _("Photometry"),
             "_EXPORT_TOOL_VERSION": "1.3.0",
             "_EXPORT_TOOL_URL": "https://github.com/dlippok/photometric-viewer",
             "_EXPORT_TOOL_ISSUE_TRACKER": "https://github.com/dlippok/photometric-viewer/issues",
@@ -275,7 +275,7 @@ class MainWindow(Adw.Window):
                 self.luminaire_content_page.update_settings(self.settings)
 
                 self.set_title(title=file.get_basename())
-                self.window_title.set_title(_("Photometric Viewer"))
+                self.window_title.set_title(_("Photometry"))
                 self.window_title.set_subtitle(file.get_basename())
 
                 self.action_set_enabled("app.show_intensity_values", True)

--- a/tests/data/photometrics/ies95/absolute_photometry.ies
+++ b/tests/data/photometrics/ies95/absolute_photometry.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/absolute_photometry_with_multiplier.ies
+++ b/tests/data/photometrics/ies95/absolute_photometry_with_multiplier.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/ellipse_opening_along_length.ies
+++ b/tests/data/photometrics/ies95/ellipse_opening_along_length.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/ellipse_opening_along_width.ies
+++ b/tests/data/photometrics/ies95/ellipse_opening_along_width.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/ellipsoid_opening_along_length.ies
+++ b/tests/data/photometrics/ies95/ellipsoid_opening_along_length.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/ellipsoid_opening_along_width.ies
+++ b/tests/data/photometrics/ies95/ellipsoid_opening_along_width.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/horizontal_cylinder_opening_along_length.ies
+++ b/tests/data/photometrics/ies95/horizontal_cylinder_opening_along_length.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/horizontal_cylinder_opening_along_width.ies
+++ b/tests/data/photometrics/ies95/horizontal_cylinder_opening_along_width.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/imperial_units.ies
+++ b/tests/data/photometrics/ies95/imperial_units.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/metric_units.ies
+++ b/tests/data/photometrics/ies95/metric_units.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/point_opening.ies
+++ b/tests/data/photometrics/ies95/point_opening.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/rectangular_opening.ies
+++ b/tests/data/photometrics/ies95/rectangular_opening.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/rectangular_opening_with_height.ies
+++ b/tests/data/photometrics/ies95/rectangular_opening_with_height.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/relative_photometry.ies
+++ b/tests/data/photometrics/ies95/relative_photometry.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/relative_photometry_with_multiplier.ies
+++ b/tests/data/photometrics/ies95/relative_photometry_with_multiplier.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/round_opening.ies
+++ b/tests/data/photometrics/ies95/round_opening.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/round_opening_with_height.ies
+++ b/tests/data/photometrics/ies95/round_opening_with_height.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ies95/sphere_opening.ies
+++ b/tests/data/photometrics/ies95/sphere_opening.ies
@@ -1,5 +1,5 @@
 IESNA:LM-63-1995
-[TEST] photometric viewer test file
+[TEST] Photometry test file
 [TESTLAB] ACME Photometrics
 [MANUFAC] ACME Inc.
 [LUMCAT] BD0150

--- a/tests/data/photometrics/ldt/absolute.ldt
+++ b/tests/data/photometrics/ldt/absolute.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/metadata.ldt
+++ b/tests/data/photometrics/ldt/metadata.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/multiple_lamp_sets.ldt
+++ b/tests/data/photometrics/ldt/multiple_lamp_sets.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/no_symmetry.ldt
+++ b/tests/data/photometrics/ldt/no_symmetry.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/rectangular_luminaire_rectangular_luminous_opening.ldt
+++ b/tests/data/photometrics/ldt/rectangular_luminaire_rectangular_luminous_opening.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 60
 30

--- a/tests/data/photometrics/ldt/rectangular_luminaire_rectangular_luminous_opening_with_heights.ldt
+++ b/tests/data/photometrics/ldt/rectangular_luminaire_rectangular_luminous_opening_with_heights.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 60
 30

--- a/tests/data/photometrics/ldt/rectangular_luminaire_round_luminous_opening.ldt
+++ b/tests/data/photometrics/ldt/rectangular_luminaire_round_luminous_opening.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 60
 30

--- a/tests/data/photometrics/ldt/rectangular_luminaire_round_luminous_opening_with_heights.ldt
+++ b/tests/data/photometrics/ldt/rectangular_luminaire_round_luminous_opening_with_heights.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 60
 30

--- a/tests/data/photometrics/ldt/relative.ldt
+++ b/tests/data/photometrics/ldt/relative.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/round_luminaire_rectangular_luminous_opening.ldt
+++ b/tests/data/photometrics/ldt/round_luminaire_rectangular_luminous_opening.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 30

--- a/tests/data/photometrics/ldt/round_luminaire_round_luminous_opening.ldt
+++ b/tests/data/photometrics/ldt/round_luminaire_round_luminous_opening.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 30

--- a/tests/data/photometrics/ldt/symmetry_about_vertical_axis.ldt
+++ b/tests/data/photometrics/ldt/symmetry_about_vertical_axis.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/symmetry_to_c0c180.ldt
+++ b/tests/data/photometrics/ldt/symmetry_to_c0c180.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/symmetry_to_c0c90c180c270.ldt
+++ b/tests/data/photometrics/ldt/symmetry_to_c0c90c180c270.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/data/photometrics/ldt/symmetry_to_c90c270.ldt
+++ b/tests/data/photometrics/ldt/symmetry_to_c90c270.ldt
@@ -9,7 +9,7 @@ TESTREP1
 Dummy LDT file
 BD0150
 BD0150.ldt
-2023-05-01 Photometric Viewer
+2023-05-01 Photometry
 120
 0
 120

--- a/tests/formats/ldt.py
+++ b/tests/formats/ldt.py
@@ -23,7 +23,7 @@ class TestLdt(unittest.TestCase):
         self.assertEqual(luminaire.metadata.luminaire_type, LuminaireType.POINT_SOURCE_WITH_VERTICAL_SYMMETRY)
         self.assertEqual(luminaire.metadata.measurement, "TESTREP1")
         self.assertEqual(luminaire.metadata.filename, "BD0150.ldt")
-        self.assertEqual(luminaire.metadata.date_and_user, "2023-05-01 Photometric Viewer")
+        self.assertEqual(luminaire.metadata.date_and_user, "2023-05-01 Photometry")
         self.assertEqual(luminaire.metadata.conversion_factor, 1.0)
         self.assertEqual(luminaire.metadata.file_units, LengthUnits.MILLIMETERS)
 


### PR DESCRIPTION
Change application icon and rename "Photometric Viewer" to "Photometry" when displayed to the user (application ID is not going to change)
See #78 