### PR TITLE
Fix wrong export tool version in the exported IES files

### DIFF
--- a/data/io.github.dlippok.photometric-viewer.metainfo.xml
+++ b/data/io.github.dlippok.photometric-viewer.metainfo.xml
@@ -190,4 +190,6 @@
         <release version="0.1.0" date="2023-04-07"/>
     </releases>
     <url type="homepage">https://github.com/dlippok/photometric-viewer</url>
+    <url type="bugtracker">https://github.com/dlippok/photometric-viewer/issues</url>
+    <url type="help">https://github.com/dlippok/photometric-viewer/discussions/categories/q-a</url>
 </component>

--- a/photometric_viewer/gui/dialogs/about.py
+++ b/photometric_viewer/gui/dialogs/about.py
@@ -1,16 +1,19 @@
 from gi.repository import Adw, Gtk
 
+from photometric_viewer.utils.project import PROJECT
+
 
 class AboutWindow:
     def __init__(self):
         self._about_window = Adw.AboutWindow(
-            application_name=_("Photometry"),
-            application_icon="io.github.dlippok.photometric-viewer",
-            developer_name="Damian Lippok",
-            version="2.0.0",
-            website="https://github.com/dlippok/photometric-viewer",
-            issue_url="https://github.com/dlippok/photometric-viewer/issues",
-            copyright="© 2023 Damian Lippok",
+            application_name=_(PROJECT.name),
+            application_icon=PROJECT.id,
+            developer_name=PROJECT.developer_name,
+            version=PROJECT.version,
+            website=PROJECT.urls.homepage,
+            issue_url=PROJECT.urls.bug_tracker,
+            support_url=PROJECT.urls.support,
+            copyright=PROJECT.copyright,
             license_type=Gtk.License.MIT_X11
         )
 

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -25,6 +25,7 @@ from photometric_viewer.gui.pages.values import IntensityValuesPage
 from photometric_viewer.model.luminaire import Luminaire
 from photometric_viewer.utils.gi.GSettings import GSettings
 from photometric_viewer.utils.gi.gio import gio_file_stream, write_string
+from photometric_viewer.utils.project import PROJECT
 
 
 class MainWindow(Adw.Window):
@@ -195,10 +196,10 @@ class MainWindow(Adw.Window):
         file: Gio.File = dialog.get_file()
 
         export_keywords = {
-            "_EXPORT_TOOL": _("Photometry"),
-            "_EXPORT_TOOL_VERSION": "1.3.0",
-            "_EXPORT_TOOL_URL": "https://github.com/dlippok/photometric-viewer",
-            "_EXPORT_TOOL_ISSUE_TRACKER": "https://github.com/dlippok/photometric-viewer/issues",
+            "_EXPORT_TOOL": PROJECT.name,
+            "_EXPORT_TOOL_VERSION": PROJECT.version,
+            "_EXPORT_TOOL_HOMEPAGE": PROJECT.urls.homepage,
+            "_EXPORT_TOOL_ISSUE_TRACKER": PROJECT.urls.bug_tracker,
             "_EXPORT_TIMESTAMP": datetime.now().isoformat()
         }
 

--- a/photometric_viewer/utils/project.py
+++ b/photometric_viewer/utils/project.py
@@ -1,0 +1,42 @@
+import importlib.metadata
+from dataclasses import dataclass
+
+@dataclass
+class ProjectUrls:
+    homepage: str
+    bug_tracker: str
+    support: str
+
+@dataclass
+class ProjectMetadata:
+    id: str
+    name: str
+    version: str
+    developer_name: str
+    urls: ProjectUrls
+    copyright: str
+
+
+def _get_metadata():
+    metadata = importlib.metadata.metadata('photometric-viewer')
+    project_urls = {
+        i.split(", ")[0]: i.split(", ")[1]
+        for i
+        in metadata.get_all('Project-URL') or {}
+    }
+
+    return ProjectMetadata(
+        id='io.github.dlippok.photometric-viewer',
+        name='Photometry',
+        version=metadata['version'],
+        developer_name=metadata["Author"],
+        urls=ProjectUrls(
+            homepage=metadata["Home-page"],
+            bug_tracker=project_urls.get("Bug Tracker", None),
+            support=project_urls.get("Support", None),
+        ),
+        copyright="© 2023 Damian Lippok"
+    )
+
+
+PROJECT = _get_metadata()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,11 @@ class InstallCommand(install):
 setup(name='photometric-viewer',
       version='2.0.0',
       description='Browse content of IES and LDT photometric files',
-      url='http://github.com/dlippok/photoetric-viewer',
+      url='http://github.com/dlippok/photometric-viewer',
+      project_urls={
+            "Bug Tracker": 'http://github.com/dlippok/photometric-viewer/issues',
+            "Support": 'https://github.com/dlippok/photometric-viewer/discussions/categories/q-a'
+      },
       author='Damian Lippok',
       author_email='mail.dalee@gmail.com',
       license='MIT',


### PR DESCRIPTION
Store application metadata centrally and get the application version, names and URLs from the setup.py file.

Close #125 