### PR TITLE
Move menu item for showing candela values to the main screen

### DIFF
--- a/photometric_viewer/gui/pages/values.py
+++ b/photometric_viewer/gui/pages/values.py
@@ -1,4 +1,5 @@
 from gi.repository import Adw, Gtk
+from gi.repository.Adw import ActionRow
 from gi.repository.Gtk import ScrolledWindow, PolicyType, Orientation, SelectionMode
 
 from photometric_viewer.gui.pages.base import BasePage
@@ -93,10 +94,13 @@ class IntensityValuesPage(BasePage):
         ]
 
         if len(values) > 200:
-            self.property_list.add(
-                _("Too many values to display"),
-                _("Select a particular C plane or gamma angle to display the values")
+            row = ActionRow(
+                title= _("Too many values to display"),
+                subtitle=_("Select a particular C plane or gamma angle to display the values"),
+                action_name="app.show_direct_ratios",
+
             )
+            self.property_list.append(row)
             return
 
         unit = None
@@ -105,7 +109,11 @@ class IntensityValuesPage(BasePage):
             case False: unit = "cd/klm"
 
         for value in sorted(values, key=lambda v: v[0]):
-            self.property_list.add(
-                f"C: {value[0][0]}°, γ: {value[0][1]}°",
-                f"{value[1]:.1f} {unit}"
+            row = ActionRow(
+                title=f"C: {value[0][0]}°, γ: {value[0][1]}°",
+                subtitle= f"{value[1]:.1f} {unit}",
+                css_classes=["property"],
+                subtitle_selectable=True
+
             )
+            self.property_list.append(row)

--- a/photometric_viewer/gui/widgets/content/header_buttons.py
+++ b/photometric_viewer/gui/widgets/content/header_buttons.py
@@ -36,10 +36,6 @@ MENU_MODELS = """
     <menu id='header-menu-other'>
         <section>
             <item>
-                <attribute name='label' translatable='yes'>Intensity Values</attribute>
-                <attribute name='action'>app.show_intensity_values</attribute>
-            </item>
-            <item>
                 <attribute name='label' translatable='yes'>Show source</attribute>
                 <attribute name='action'>app.show_source</attribute>
             </item>

--- a/photometric_viewer/gui/widgets/content/photometry.py
+++ b/photometric_viewer/gui/widgets/content/photometry.py
@@ -84,3 +84,14 @@ class LuminairePhotometricProperties(Box):
             )
             row.add_suffix(icon)
             self.property_list.append(row)
+
+        if luminaire.intensity_values:
+            icon = Gtk.Image(icon_name="go-next-symbolic")
+            row = ActionRow(
+                title=_("Intensity values"),
+                action_name="app.show_intensity_values",
+                activatable_widget=icon,
+
+            )
+            row.add_suffix(icon)
+            self.property_list.append(row)


### PR DESCRIPTION
Instead showing a menu item in hamburger menu, move the opening of candela values to the main screen of the application, similarly to the direct room indices