### PR TITLE
Quicker editing of file source

### DIFF
--- a/photometric_viewer/gui/pages/source.py
+++ b/photometric_viewer/gui/pages/source.py
@@ -29,6 +29,7 @@ class SourceViewPage(BasePage):
 
         self.source_text_view.set_show_line_numbers(True)
         self.source_text_view.get_buffer().connect("changed", self.on_update_content)
+        self.connect("shown", self.on_shown)
 
         self.lang_manager: GtkSource.LanguageManager = GtkSource.LanguageManager.get_default()
         self.lang_manager.append_search_path(SPECS_DIR)
@@ -46,6 +47,9 @@ class SourceViewPage(BasePage):
 
     def on_update_content(self, *args):
         self._update_language()
+
+    def on_shown(self, *args):
+        self.source_text_view.grab_focus()
 
     def open_stream(self, f: typing.IO):
         self.source_text_view.get_buffer().set_text(f.read())

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -137,6 +137,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.open_stream(stram)
         stram.seek(0)
         self.source_view_page.open_stream(io.StringIO(""))
+        self.show_source()
 
     def on_open(self, *args):
         if self.source_view_page.source_text_view.get_buffer().get_modified():


### PR DESCRIPTION
Small tweaks allowing the user to edit file source quicker:

- When opening source view page, move focus to the text view so that the user can start typing directly
- When creating new file open the source view page directly to avoid showing useless empty file preview