### PR TITLE
Zoom in light distribution curve

### DIFF
--- a/photometric_viewer/gui/pages/direct_ratios.py
+++ b/photometric_viewer/gui/pages/direct_ratios.py
@@ -1,6 +1,6 @@
 from gi.repository import Adw, Gtk
 from gi.repository.Adw import ActionRow
-from gi.repository.Gtk import ScrolledWindow, PolicyType, Orientation, SelectionMode
+from gi.repository.Gtk import ScrolledWindow, PolicyType, Orientation
 
 from photometric_viewer.config.appearance import CLAMP_MAX_WIDTH
 from photometric_viewer.gui.pages.base import BasePage

--- a/photometric_viewer/gui/pages/ldc_zoom.py
+++ b/photometric_viewer/gui/pages/ldc_zoom.py
@@ -1,0 +1,38 @@
+from gi.repository import Adw
+from gi.repository.Gtk import Box, Orientation, PolicyType, ScrolledWindow, Align
+
+from photometric_viewer.config.appearance import CLAMP_MAX_WIDTH
+from photometric_viewer.gui.pages.base import BasePage
+from photometric_viewer.gui.widgets.content.diagram import PhotometricDiagram
+from photometric_viewer.model.luminaire import Luminaire
+
+
+class LdcZoomPage(BasePage):
+    def __init__(self, **kwargs):
+        super().__init__(_("Light Distribution Curve"), **kwargs)
+
+        box = Box(
+            css_classes=["card"],
+            orientation=Orientation.VERTICAL,
+            spacing=16,
+            margin_top=50,
+            margin_bottom=50,
+            margin_start=16,
+            margin_end=16,
+            valign=Align.START
+        )
+
+        self.diagram = PhotometricDiagram()
+        box.append(self.diagram)
+
+        clamp = Adw.Clamp(maximum_size=CLAMP_MAX_WIDTH)
+        clamp.set_child(box)
+
+        scrolled_window = ScrolledWindow()
+        scrolled_window.set_child(clamp)
+        scrolled_window.set_vexpand(True)
+        scrolled_window.set_policy(PolicyType.NEVER, PolicyType.AUTOMATIC)
+        self.set_content(scrolled_window)
+
+    def set_photometry(self, luminaire: Luminaire):
+        self.diagram.set_photometry(luminaire)

--- a/photometric_viewer/gui/widgets/content/diagram.py
+++ b/photometric_viewer/gui/widgets/content/diagram.py
@@ -16,7 +16,6 @@ class PhotometricDiagram(Gtk.DrawingArea):
         self.style_manager.connect("notify", self.on_style_manager_notify)
         self.selected_theme = plotter_themes.THEMES[0]
 
-        self.set_css_classes(["card"])
         self.set_draw_func(self.on_draw)
         self.luminaire = None
         self.plotter = LightDistributionPlotter()

--- a/photometric_viewer/gui/widgets/content/header.py
+++ b/photometric_viewer/gui/widgets/content/header.py
@@ -1,3 +1,4 @@
+from gi.repository import Adw, Gtk, Gdk
 from gi.repository.Gtk import Box, Orientation, Label, Align
 from gi.repository.Pango import WrapMode
 
@@ -69,7 +70,16 @@ class LuminaireHeader(Box):
         properties_box.append(self.description_label)
         properties_box.append(self.header_buttons)
 
-        self.append(self.diagram)
+        self.diagram_zoom_button = Gtk.Button(
+            css_classes=["card"],
+            valign=Gtk.Align.START,
+            cursor=Gdk.Cursor.new_from_name("zoom-in"),
+            child=self.diagram,
+            visible=False,
+            action_name="win.show_ldc_zoom"
+        )
+
+        self.append(self.diagram_zoom_button)
         self.append(properties_box)
 
     def set_photometry(self, luminaire: Luminaire):
@@ -87,3 +97,4 @@ class LuminaireHeader(Box):
 
         self.diagram.set_photometry(luminaire)
         self.header_buttons.set_photometry(luminaire)
+        self.diagram_zoom_button.set_visible(luminaire.intensity_values)

--- a/photometric_viewer/gui/widgets/ldc_export/diagram.py
+++ b/photometric_viewer/gui/widgets/ldc_export/diagram.py
@@ -8,7 +8,7 @@ from photometric_viewer.utils.plotters import LightDistributionPlotter, LightDis
 class PhotometricDiagramPreview(Gtk.DrawingArea):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.set_css_classes(["boxed-list"])
+        self.set_css_classes(["card"])
         self.set_name("photometric_diagram")
         self.set_draw_func(self.on_draw)
         self.luminaire = None

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -22,14 +22,15 @@ from photometric_viewer.gui.pages.direct_ratios import DirectRatiosPage
 from photometric_viewer.gui.pages.geometry import GeometryPage
 from photometric_viewer.gui.pages.lamp_set import LampSetPage
 from photometric_viewer.gui.pages.ldc_export import LdcExportPage
+from photometric_viewer.gui.pages.ldc_zoom import LdcZoomPage
 from photometric_viewer.gui.pages.photometry import PhotometryPage
 from photometric_viewer.gui.pages.source import SourceViewPage
 from photometric_viewer.gui.pages.values import IntensityValuesPage
 from photometric_viewer.gui.widgets.common.split_view import SplitView
 from photometric_viewer.model.luminaire import Luminaire
+from photometric_viewer.utils.gi.GSettings import SettingsManager
 from photometric_viewer.utils.gi.gio import gio_file_stream, write_string
 from photometric_viewer.utils.project import PROJECT
-from photometric_viewer.utils.gi.GSettings import SettingsManager
 
 
 class MainWindow(Adw.ApplicationWindow):
@@ -62,6 +63,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.geometry_page = GeometryPage()
         self.lamp_set_page = LampSetPage()
         self.ballast_page = BallastPage()
+        self.ldc_zoom_page = LdcZoomPage()
 
         self.navigation_view.replace([self.luminaire_content_page])
         self.on_new()
@@ -118,6 +120,7 @@ class MainWindow(Adw.ApplicationWindow):
             [
                 ("open", self.on_open),
                 ("new", self.on_new),
+                ("show_ldc_zoom", self.on_show_ldc_zoom)
             ]
         )
 
@@ -135,6 +138,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.direct_ratios_page.set_photometry(luminaire)
         self.photometry_page.set_photometry(luminaire)
         self.geometry_page.set_photometry(luminaire)
+        self.ldc_zoom_page.set_photometry(luminaire)
 
         self.opened_photometry = luminaire
 
@@ -266,6 +270,9 @@ class MainWindow(Adw.ApplicationWindow):
     def on_drop(self, target, file, *args):
         self.open_file(file)
         return True
+
+    def on_show_ldc_zoom(self, *args):
+        self.navigation_view.push(self.ldc_zoom_page)
 
     def open_stream(self, f: IO):
         if self.is_opening:


### PR DESCRIPTION
The user can click on the light distribution curve to see a zoomed in view. Useful for small window sizes