### PR TITLE
Do not return to start page after editing text content

### DIFF
--- a/photometric_viewer/gui/widgets/content/header.py
+++ b/photometric_viewer/gui/widgets/content/header.py
@@ -1,11 +1,10 @@
-from gi.repository import Adw, Gtk, Gdk
+from gi.repository import Gtk, Gdk
 from gi.repository.Gtk import Box, Orientation, Label, Align
 from gi.repository.Pango import WrapMode
 
 from photometric_viewer.gui.widgets.content.diagram import PhotometricDiagram
 from photometric_viewer.gui.widgets.content.header_buttons import HeaderButtons
 from photometric_viewer.model.luminaire import Luminaire
-from photometric_viewer.model.settings import Settings
 
 
 class LuminaireHeader(Box):

--- a/photometric_viewer/gui/window.py
+++ b/photometric_viewer/gui/window.py
@@ -304,7 +304,6 @@ class MainWindow(Adw.ApplicationWindow):
                     ("open_url", self.on_open_url, "s")
                 ]
             )
-            self.show_start_page()
         finally:
             self.is_opening = False
 
@@ -327,6 +326,7 @@ class MainWindow(Adw.ApplicationWindow):
                 f.seek(0)
                 self.source_view_page.open_stream(f)
                 self.update_file(file)
+                self.show_start_page()
 
         except GLib.GError as e:
             logging.exception("Could not open photometric file")


### PR DESCRIPTION
Only show start page when opening files, not when editing existing content