### PR TITLE
Reduce margins of pages in the sidebar

### DIFF
--- a/photometric_viewer/gui/pages/ballast_set.py
+++ b/photometric_viewer/gui/pages/ballast_set.py
@@ -17,8 +17,8 @@ class BallastPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )

--- a/photometric_viewer/gui/pages/content.py
+++ b/photometric_viewer/gui/pages/content.py
@@ -21,8 +21,8 @@ class PhotometryContentPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16,
         )

--- a/photometric_viewer/gui/pages/direct_ratios.py
+++ b/photometric_viewer/gui/pages/direct_ratios.py
@@ -18,8 +18,8 @@ class DirectRatiosPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )

--- a/photometric_viewer/gui/pages/geometry.py
+++ b/photometric_viewer/gui/pages/geometry.py
@@ -19,8 +19,8 @@ class GeometryPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )

--- a/photometric_viewer/gui/pages/lamp_set.py
+++ b/photometric_viewer/gui/pages/lamp_set.py
@@ -23,8 +23,8 @@ class LampSetPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )

--- a/photometric_viewer/gui/pages/ldc_export.py
+++ b/photometric_viewer/gui/pages/ldc_export.py
@@ -26,8 +26,8 @@ class LdcExportPage(BasePage):
         box = Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16,
         )

--- a/photometric_viewer/gui/pages/ldc_zoom.py
+++ b/photometric_viewer/gui/pages/ldc_zoom.py
@@ -15,8 +15,8 @@ class LdcZoomPage(BasePage):
             css_classes=["card"],
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16,
             valign=Align.START

--- a/photometric_viewer/gui/pages/luminaire_count_calc.py
+++ b/photometric_viewer/gui/pages/luminaire_count_calc.py
@@ -19,8 +19,8 @@ class NumberOfLuminairesCalculationPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )

--- a/photometric_viewer/gui/pages/photometry.py
+++ b/photometric_viewer/gui/pages/photometry.py
@@ -19,8 +19,8 @@ class PhotometryPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )

--- a/photometric_viewer/gui/pages/values.py
+++ b/photometric_viewer/gui/pages/values.py
@@ -33,8 +33,8 @@ class IntensityValuesPage(BasePage):
         box = Gtk.Box(
             orientation=Orientation.VERTICAL,
             spacing=16,
-            margin_top=50,
-            margin_bottom=50,
+            margin_top=16,
+            margin_bottom=16,
             margin_start=16,
             margin_end=16
         )


### PR DESCRIPTION
Use smaller margins for consistent, more pleasant look and to fit more information without scrolling.